### PR TITLE
fix: correct CHANGELOG extraction pattern in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
 
           # Extract the section for this version from CHANGELOG.md
           # commitizen format: ## v0.1.0a2 (2025-12-08)
-          CHANGELOG_CONTENT=$(awk "/## v${VERSION} /,/## v/" CHANGELOG.md | sed '$d' | tail -n +2)
+          CHANGELOG_CONTENT=$(awk "/## v${VERSION} \(/{flag=1; next} /^## v/{flag=0} flag" CHANGELOG.md)
 
           # If no content found, use a default message
           if [ -z "$CHANGELOG_CONTENT" ]; then


### PR DESCRIPTION
## Summary

- Fix GitHub Actions release workflow CHANGELOG extraction to work with commitizen format
- Previous awk pattern failed to capture content between version headers
- Tested locally with v0.1.0a2 section extraction

## Problem

After merging the commitizen migration, the v0.1.0a2 release was created with only "Release version 0.1.0a2" in the body instead of the full CHANGELOG content.

**Root cause**: The awk command pattern `/## v${VERSION} /,/## v/` didn't correctly extract the content between version headers in commitizen's CHANGELOG format.

## Solution

Replace the range-based awk pattern with a flag-based approach:

```bash
# Before (incorrect)
CHANGELOG_CONTENT=$(awk "/## v${VERSION} /,/## v/" CHANGELOG.md | sed '$d' | tail -n +2)

# After (correct)
CHANGELOG_CONTENT=$(awk "/## v${VERSION} \(/{flag=1; next} /^## v/{flag=0} flag" CHANGELOG.md)
```

This properly extracts content between `## v0.1.0a2 (2025-12-08)` and the next `## v0.1.0a1 (...)` header.

## Test Plan

- [x] Tested locally with `VERSION="0.1.0a2"` against current CHANGELOG.md
- [x] Verified correct extraction of Feat/Fix/Refactor sections
- [ ] Verify next release (e.g., v0.1.0a3) creates proper GitHub Release body

🤖 Generated with [Claude Code](https://claude.com/claude-code)