### PR TITLE
feat: support unlimited evaluation score range (Feature 037)

### DIFF
--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -242,7 +242,7 @@ execution_idとチームIDによる高速検索を実現します。
 | `team_id` | TEXT | NOT NULL |
 | `team_name` | TEXT | NOT NULL |
 | `round_number` | INTEGER | NOT NULL |
-| `evaluation_score` | DOUBLE | NOT NULL, CHECK (evaluation_score >= 0.0 AND evaluation_score <= 1.0) |
+| `evaluation_score` | DOUBLE | NOT NULL |
 | `evaluation_feedback` | TEXT | - |
 | `submission_content` | TEXT | NOT NULL |
 | `submission_format` | TEXT | DEFAULT 'structured_json' |
@@ -252,11 +252,11 @@ execution_idとチームIDによる高速検索を実現します。
 #### 制約
 
 ```sql
--- 評価スコア範囲チェック（DB level validation）
-CHECK (evaluation_score >= 0.0 AND evaluation_score <= 1.0)
+-- UNIQUE制約（execution_id, team_id, round_number）
+UNIQUE (execution_id, team_id, round_number)
 ```
 
-評価スコアは0.0～1.0の範囲内である必要があります。範囲外の値を保存しようとした場合、データベースレベルでエラーが発生します（憲章Article 9準拠）。
+同一実行・同一チーム・同一ラウンドの組み合わせは一意です。
 
 ```{admonition} Orchestrator実行との関係
 :class: info
@@ -265,7 +265,7 @@ Orchestrator実行時、各チームの`RoundResult`がこのテーブルに記�
 
 - **複数チーム記録**: 並列実行された全チームの結果が個別に記録されます
 - **スコアベース選択**: `evaluation_score`を基準に最高スコアチームが特定されます
-- **スコア表示**: 内部は0.0-1.0スケールで記録、CLI表示時は0-100に変換されます
+- **スコア表示**: 任意の実数値（無制限範囲、負の値や100を超える値も許容）
 - **失敗チーム**: 失敗したチームは記録されません（Orchestrator層で隔離）
 
 詳細は [Orchestratorガイド](orchestrator-guide.md) を参照してください。
@@ -299,17 +299,18 @@ Orchestrator実行時、各チームの`RoundResult`がこのテーブルに記�
 - **保存処理**: `RoundController.run_round()` (controller.py) → `AggregationStore._save_to_leader_board_sync()` (aggregation_store.py)
 
 ##### `evaluation_score`
-- **説明**: 評価スコア（内部保存形式）
+- **説明**: 評価スコア（無制限範囲、任意の実数値）
 - **発行元**: `Evaluator.evaluate()` → `EvaluationResult.overall_score`（任意の実数値）
-- **スコア変換**: 実装依存（LLMJudgeMetricsのみを使用する場合は通常0-100スケール、カスタムメトリクスを含む場合は任意の値）
+- **スコア範囲**: 無制限（負の値、100を超える値、任意の実数値を許容）
 - **保存処理**: `AggregationStore.save_to_leader_board()` → `AggregationStore._save_to_leader_board_sync()` (aggregation_store.py)
-- **バリデーション**: 実装依存（現在は制約なし）
+- **バリデーション**: なし（Pydanticモデル、データベース共に制約なし）
 
 :::{note}
 **スコア範囲について**:
-- 組み込みLLMJudgeMetrics（ClarityCoherence、Coverage、Relevance等）は0-100スケールを返します
+- 組み込みLLMJudgeMetrics（ClarityCoherence、Coverage、Relevance等）は通常0-100スケールを返します
 - カスタムメトリクスでは負の値や100を超える値を含む任意の実数値が許容されます
 - 重み付き平均の`overall_score`も同様に任意の実数値を取り得ます
+- Feature 037 (evaluator-score-unlimited) により、スコア制限が完全に撤廃されました
 :::
 
 ##### `evaluation_feedback`
@@ -512,7 +513,7 @@ CHECK (status IN ('completed', 'partial_failure', 'failed'))
 - **NULL条件**: チーム結果が空の場合（全チーム失敗）はNULL
 
 ##### `best_score`
-- **説明**: 最高評価スコア（0.0-1.0スケール）
+- **説明**: 最高評価スコア（無制限範囲、任意の実数値）
 - **発行元**: `Orchestrator.execute()` (orchestrator.py) - 最大`evaluation_score`を特定
 - **保存処理**: `AggregationStore._save_execution_summary_sync()` (aggregation_store.py)
 - **NULL条件**: チーム結果が空の場合（全チーム失敗）はNULL
@@ -731,13 +732,8 @@ raise EnvironmentError(
 
 ### 評価スコア範囲
 
-`evaluation_score`は0.0～1.0の範囲内である必要があります。範囲外の値を保存しようとした場合：
+`evaluation_score`は無制限範囲の任意の実数値を許容します（Feature 037: evaluator-score-unlimited）。
 
-```python
-raise ValueError(
-    f"evaluation_score must be between 0.0 and 1.0, got {evaluation_score}. "
-    "This violates the contract specification."
-)
-```
-
-データベースレベルのCHECK制約も設定されており、二重の検証により契約違反を防止します。
+- 負の値や100を超える値も有効です
+- Pydanticモデルレベル、データベースレベルともに制約はありません
+- カスタムメトリクスの実装により自由にスコアリング方式を定義できます

--- a/src/mixseek/models/leaderboard.py
+++ b/src/mixseek/models/leaderboard.py
@@ -24,7 +24,7 @@ class LeaderBoardEntry(BaseModel):
     round_number: int = Field(ge=1, description="Round number")
     submission_content: str = Field(description="Submission content from team")
     submission_format: str = Field(default="md", description="Submission format (default: md)")
-    score: float = Field(ge=0.0, le=100.0, description="Evaluation score from Evaluator (0-100)")
+    score: float = Field(description="Evaluation score from Evaluator")
     score_details: dict[str, Any] = Field(description="Detailed score breakdown and comments (JSON format)")
     final_submission: bool = Field(default=False, description="Flag indicating if this is the final round submission")
     exit_reason: str | None = Field(

--- a/src/mixseek/orchestrator/models.py
+++ b/src/mixseek/orchestrator/models.py
@@ -73,7 +73,7 @@ class RoundResult(BaseModel):
     team_name: str = Field(description="チーム名")
     round_number: int = Field(ge=1, description="ラウンド番号")
     submission_content: str = Field(description="Submissionテキスト")
-    evaluation_score: float = Field(ge=0.0, le=1.0, description="評価スコア（0.0-1.0スケール）")
+    evaluation_score: float = Field(description="評価スコア")
     evaluation_feedback: str = Field(description="評価フィードバック")
     usage: RunUsage = Field(description="リソース使用量")
     execution_time_seconds: float = Field(gt=0, description="実行時間（秒）")
@@ -105,7 +105,7 @@ class ExecutionSummary(BaseModel):
         default_factory=list, description="各チームの最高スコアSubmission (LeaderBoardEntry)"
     )
     best_team_id: str | None = Field(default=None, description="最高スコアチームID")
-    best_score: float | None = Field(default=None, ge=0.0, le=100.0, description="最高評価スコア（0-100スケール）")
+    best_score: float | None = Field(default=None, description="最高評価スコア")
     total_execution_time_seconds: float = Field(gt=0, description="総実行時間（秒）")
     failed_teams_info: list[FailedTeamInfo] = Field(default_factory=list, description="失敗チームの詳細情報")
     created_at: datetime = Field(

--- a/src/mixseek/round_controller/models.py
+++ b/src/mixseek/round_controller/models.py
@@ -35,7 +35,7 @@ class RoundState(BaseModel):
 
     round_number: int = Field(ge=1, description="Round number")
     submission_content: str = Field(description="Submission content")
-    evaluation_score: float = Field(ge=0.0, le=100.0, description="Evaluation score (0-100 scale)")
+    evaluation_score: float = Field(description="Evaluation score")
     score_details: dict[str, Any] = Field(
         description="Detailed score breakdown (JSON format, consistent with LeaderBoardEntry)"
     )

--- a/src/mixseek/ui/models/execution.py
+++ b/src/mixseek/ui/models/execution.py
@@ -31,7 +31,7 @@ class Execution(BaseModel):
     prompt: str = Field(..., description="ユーザプロンプト")
     status: ExecutionStatus = Field(..., description="実行ステータス")
     best_team_id: str | None = Field(None, description="最高スコアチームID")
-    best_score: float | None = Field(None, description="最高評価スコア（0-100）")
+    best_score: float | None = Field(None, description="最高評価スコア")
     duration_seconds: float | None = Field(None, description="実行時間（秒）")
     created_at: datetime = Field(..., description="実行開始日時")
     completed_at: datetime | None = Field(None, description="実行完了日時")
@@ -49,8 +49,7 @@ class Execution(BaseModel):
     def result_summary(self) -> str | None:
         """結果サマリー（best_team_idとbest_scoreから生成）."""
         if self.best_team_id and self.best_score is not None:
-            score_display = round(self.best_score)  # 整数に四捨五入（既に0-100の範囲）
-            return f"Best Team: {self.best_team_id} (Score: {score_display})"
+            return f"Best Team: {self.best_team_id} (Score: {self.best_score})"
         return None
 
     class Config:

--- a/src/mixseek/ui/models/round_models.py
+++ b/src/mixseek/ui/models/round_models.py
@@ -94,7 +94,7 @@ class TeamScoreHistory(BaseModel):
         team_id: チーム識別子
         team_name: チーム名
         round_number: ラウンド番号
-        score: 評価スコア（0.0-100.0）
+        score: 評価スコア
 
     Example:
         >>> history = TeamScoreHistory.from_db_row(
@@ -107,7 +107,7 @@ class TeamScoreHistory(BaseModel):
     team_id: str = Field(..., description="チーム識別子")
     team_name: str = Field(..., description="チーム名")
     round_number: int = Field(..., ge=1, description="ラウンド番号")
-    score: float = Field(..., ge=0.0, description="評価スコア")
+    score: float = Field(..., description="評価スコア")
 
     @classmethod
     def from_db_row(cls, row: tuple[str | int | float, ...]) -> "TeamScoreHistory":
@@ -145,7 +145,7 @@ class TeamSubmission(BaseModel):
         team_name: チーム名
         round_number: ラウンド番号
         submission_content: サブミッション内容（マークダウン形式）
-        score: 評価スコア（0.0-100.0）
+        score: 評価スコア
         score_details: スコア詳細（JSON）
         created_at: 作成日時
         final_submission: 最終サブミッションフラグ
@@ -163,7 +163,7 @@ class TeamSubmission(BaseModel):
     team_name: str = Field(..., description="チーム名")
     round_number: int = Field(..., ge=1, description="ラウンド番号")
     submission_content: str = Field(..., description="サブミッション内容")
-    score: float = Field(..., ge=0.0, description="評価スコア")
+    score: float = Field(..., description="評価スコア")
     score_details: str | None = Field(None, description="スコア詳細JSON")
     created_at: datetime = Field(..., description="作成日時")
     final_submission: bool = Field(False, description="最終サブミッションフラグ")

--- a/tests/unit/orchestrator/test_models.py
+++ b/tests/unit/orchestrator/test_models.py
@@ -88,19 +88,34 @@ def test_round_result_creation() -> None:
 
 
 def test_round_result_validation() -> None:
-    """RoundResult バリデーションテスト"""
-    with pytest.raises(ValueError):
-        RoundResult(
-            execution_id="550e8400-e29b-41d4-a716-446655440000",
-            team_id="team-001",
-            team_name="Test Team",
-            round_number=1,
-            submission_content="テスト",
-            evaluation_score=1.5,  # 範囲外
-            evaluation_feedback="",
-            usage=RunUsage(),
-            execution_time_seconds=30.0,
-        )
+    """RoundResult unlimited score support test"""
+    # Test that unlimited score range is supported (negative, >100, etc.)
+    result = RoundResult(
+        execution_id="550e8400-e29b-41d4-a716-446655440000",
+        team_id="team-001",
+        team_name="Test Team",
+        round_number=1,
+        submission_content="テスト",
+        evaluation_score=150.5,  # Score > 100 allowed
+        evaluation_feedback="",
+        usage=RunUsage(),
+        execution_time_seconds=30.0,
+    )
+    assert result.evaluation_score == 150.5
+
+    # Test negative scores are also allowed
+    result_negative = RoundResult(
+        execution_id="550e8400-e29b-41d4-a716-446655440000",
+        team_id="team-002",
+        team_name="Test Team 2",
+        round_number=1,
+        submission_content="テスト",
+        evaluation_score=-42.3,  # Negative score allowed
+        evaluation_feedback="",
+        usage=RunUsage(),
+        execution_time_seconds=30.0,
+    )
+    assert result_negative.evaluation_score == -42.3
 
 
 # T006: ExecutionSummary Tests


### PR DESCRIPTION
## 概要

評価スコアの制約を削除し、負の値や100を超える値を含む無制限範囲のスコアをサポートします。

- すべてのPydanticモデルのスコアフィールドから`ge=0.0, le=100.0`のバリデータを削除
- データベーススキーマドキュメントを更新して無制限スコア範囲のサポートを反映
- 負のスコアおよび100超過のスコアが正しくサポートされることを検証するテストを更新
- カスタムメトリクスが人為的な制限なしに任意のスコアリング方式を使用できるようにする

## 変更内容

**モデル (5ファイル)**:
- `LeaderBoardEntry.score`: ge/le制約を削除
- `RoundResult.evaluation_score`: ge/le制約を削除
- `ExecutionSummary.best_score`: ge/le制約を削除
- `RoundState.evaluation_score`: ge/le制約を削除
- `Execution.best_score`: 制約を削除、result_summaryのフォーマットを更新

**ドキュメント**:
- `docs/database-schema.md`: すべてのスコアフィールドの説明を無制限範囲に更新

**テスト (2ファイル)**:
- `tests/database/test_schema.py`: CHECK制約テストを無制限スコアサポートテストに置き換え
- `tests/unit/orchestrator/test_models.py`: バリデーションエラーテストを正負のスコアテストに置き換え

## テスト計画

- [x] pytestを実行してすべてのテストが通ることを確認
- [x] 負のスコアがPydanticモデルで受け入れられることを確認
- [x] 100超過のスコアがPydanticモデルで受け入れられることを確認
- [x] 無制限スコアでデータベーススキーマテストが通ることを確認
- [x] オーケストレータモデルのバリデーションテストが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)