### PR TITLE
feature/issue-92 「はじめに - 5分でスタート」からVertex AIに関する記述を削除

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -116,9 +116,8 @@ mixseek-workspace/
 
 ## ステップ2: API認証の設定
 
-Google Gemini APIの認証情報を設定します。
-
-### Gemini Developer API
+このガイドのデモを実行するには、Google Gemini APIの認証情報が必要です。
+以下のコマンドでAPIキーを設定してください。
 
 ```bash
 export GOOGLE_API_KEY=your-api-key


### PR DESCRIPTION
# 概要
- Vertex AIのクレデンシャル情報を使用する方法を、「はじめに - 5分でスタート」ページから削除した。
- 同ページのバージョン情報と更新日についても削除した。

# 変更理由
- GOOGLE_API_KEYを使用しないとページで紹介しているデモが実行できないため
- ドキュメントページのバージョン情報と更新日のメンテナンスの負担を無くすため
