### PR TITLE
typo fix: Update API key variable name in search_news_multi_perspective.toml

### DIFF
--- a/src/mixseek/config/templates/search_news_multi_perspective.toml
+++ b/src/mixseek/config/templates/search_news_multi_perspective.toml
@@ -7,7 +7,7 @@
 # 使用方法:
 #   export MIXSEEK_WORKSPACE=$HOME/mixseek-workspace
 #   export GOOGLE_API_KEY=your-api-key
-#   export XAI_API_KEY=your-xai-api-key  # Grok用（視点2で使用）
+#   export GROK_API_KEY=your-xai-api-key  # Grok用（視点2で使用）
 #
 #   mixseek exec \
 #     --workspace $MIXSEEK_WORKSPACE \


### PR DESCRIPTION
### Changes Made
- typo fix: Renamed the GROK API key variable in `search_news_multi_perspective.toml` 
it's `GROK_API_KEY` in other places and it should be the correct env name.

### Additional Notes
- No functional changes; only variable renaming.

### Checklist
- [ ] Tests added/updated, if applicable.
- [ ] Documentation updated, if applicable.
- [ ] Verified functional integrity after changes.