### PR TITLE
fix(cli): return proper exit codes from exec command

### DIFF
--- a/src/mixseek/cli/commands/exec.py
+++ b/src/mixseek/cli/commands/exec.py
@@ -259,7 +259,7 @@ def _print_leaderboard_table(summary: ExecutionSummary) -> None:
     table.add_column("Status", width=12)
 
     # 部分成功チームIDの特定
-    partial_team_ids = {r.team_id for r in summary.team_results} & {f.team_id for f in summary.failed_teams_info}
+    partial_team_ids = summary.partial_team_ids
 
     # 成功チーム（部分成功含む）をスコア降順でソート
     sorted_results = sorted(summary.team_results, key=lambda r: r.score, reverse=True)
@@ -300,7 +300,7 @@ def _print_text_summary(summary: ExecutionSummary) -> None:
         summary: 実行サマリー
     """
     # 部分成功チームIDの特定
-    partial_team_ids = {r.team_id for r in summary.team_results} & {f.team_id for f in summary.failed_teams_info}
+    partial_team_ids = summary.partial_team_ids
 
     # 成功チーム結果表示
     for result in summary.team_results:

--- a/src/mixseek/cli/commands/exec.py
+++ b/src/mixseek/cli/commands/exec.py
@@ -223,9 +223,23 @@ def exec_command(
             # Note: exec コマンドでは常に DB に保存
             _output_results(summary, output_format)
 
+            # 9. 終了コード判定
+            if not summary.failed_teams_info:
+                # 全チーム成功
+                exit_code = 0
+            elif summary.team_results:
+                # 部分成功（成功チームあり + 失敗チームあり）
+                exit_code = 1
+            else:
+                # 全チーム失敗
+                exit_code = 2
+            if exit_code != 0:
+                raise typer.Exit(code=exit_code)
+        except typer.Exit:
+            raise
         except Exception as e:
             typer.echo(f"Error: {e}", err=True)
-            raise typer.Exit(code=1) from e
+            raise typer.Exit(code=2) from e
         finally:
             # Cleanup: Close all HTTP clients
             await close_all_auth_clients()

--- a/src/mixseek/cli/commands/exec.py
+++ b/src/mixseek/cli/commands/exec.py
@@ -224,17 +224,13 @@ def exec_command(
             _output_results(summary, output_format)
 
             # 9. 終了コード判定
-            if not summary.failed_teams_info:
-                # 全チーム成功
-                exit_code = 0
-            elif summary.team_results:
-                # 部分成功（成功チームあり + 失敗チームあり）
-                exit_code = 1
-            else:
-                # 全チーム失敗
-                exit_code = 2
-            if exit_code != 0:
-                raise typer.Exit(code=exit_code)
+            if summary.failed_teams_info:
+                if summary.team_results:
+                    # 部分成功（成功チームあり + 失敗チームあり）
+                    raise typer.Exit(code=1)
+                else:
+                    # 全チーム失敗
+                    raise typer.Exit(code=2)
         except typer.Exit:
             raise
         except Exception as e:

--- a/src/mixseek/cli/commands/exec.py
+++ b/src/mixseek/cli/commands/exec.py
@@ -258,27 +258,32 @@ def _print_leaderboard_table(summary: ExecutionSummary) -> None:
     table.add_column("Score", justify="right", width=8)
     table.add_column("Status", width=12)
 
-    # 成功チームをスコア降順でソート
+    # 部分成功チームIDの特定
+    partial_team_ids = {r.team_id for r in summary.team_results} & {f.team_id for f in summary.failed_teams_info}
+
+    # 成功チーム（部分成功含む）をスコア降順でソート
     sorted_results = sorted(summary.team_results, key=lambda r: r.score, reverse=True)
 
     # 成功チームを追加
     for rank, result in enumerate(sorted_results, 1):
         # スコアは既に0-100スケール
+        status = "⚠️ Partial" if result.team_id in partial_team_ids else "✅ Completed"
         table.add_row(
             str(rank),
             result.team_name,
             f"{result.score:.2f}",
-            "✅ Completed",
+            status,
         )
 
-    # 失敗チームを追加
+    # 完全失敗チームのみ追加（部分成功チームはリーダーボードに表示済み）
     for failed in summary.failed_teams_info:
-        table.add_row(
-            "—",
-            failed.team_name,
-            "—",
-            "❌ Failed",
-        )
+        if failed.team_id not in partial_team_ids:
+            table.add_row(
+                "—",
+                failed.team_name,
+                "—",
+                "❌ Failed",
+            )
 
     # テーブル表示
     console.print()
@@ -294,9 +299,15 @@ def _print_text_summary(summary: ExecutionSummary) -> None:
     Args:
         summary: 実行サマリー
     """
+    # 部分成功チームIDの特定
+    partial_team_ids = {r.team_id for r in summary.team_results} & {f.team_id for f in summary.failed_teams_info}
+
     # 成功チーム結果表示
     for result in summary.team_results:
-        typer.echo(f"✅ Team {result.team_id}: {result.team_name} (Round {result.round_number})")
+        if result.team_id in partial_team_ids:
+            typer.echo(f"⚠️  Team {result.team_id}: {result.team_name} (Round {result.round_number}) [Partial]")
+        else:
+            typer.echo(f"✅ Team {result.team_id}: {result.team_name} (Round {result.round_number})")
         # スコアは既に0-100スケール
         typer.echo(f"   Score: {result.score:.2f}")
         typer.echo(f"   Exit Reason: {result.exit_reason or 'N/A'}\n")
@@ -305,7 +316,10 @@ def _print_text_summary(summary: ExecutionSummary) -> None:
     if summary.failed_teams_info:
         typer.echo("❌ Failed Teams:")
         for failed in summary.failed_teams_info:
-            typer.echo(f"   • {failed.team_id}: {failed.team_name}")
+            if failed.team_id in partial_team_ids:
+                typer.echo(f"   • {failed.team_id}: {failed.team_name} [Partial - see leaderboard]")
+            else:
+                typer.echo(f"   • {failed.team_id}: {failed.team_name}")
             typer.echo(f"     Error: {failed.error_message}\n")
 
     # 最高スコアチーム表示
@@ -327,6 +341,8 @@ def _print_text_summary(summary: ExecutionSummary) -> None:
     typer.echo(f"\nTotal Teams:      {summary.total_teams}")
     typer.echo(f"Completed Teams:  {summary.completed_teams}")
     typer.echo(f"Failed Teams:     {summary.failed_teams}")
+    if summary.partial_teams > 0:
+        typer.echo(f"Partial Teams:    {summary.partial_teams}")
     typer.echo(f"Execution Time:   {summary.total_execution_time_seconds:.1f}s")
     # exec コマンドでは常に DB に保存
     typer.echo("\n💾 Results saved to DuckDB")

--- a/src/mixseek/orchestrator/models.py
+++ b/src/mixseek/orchestrator/models.py
@@ -91,6 +91,21 @@ class FailedTeamInfo(BaseModel):
     error_message: str = Field(description="エラーメッセージ")
 
 
+class PartialTeamFailureError(Exception):
+    """1ラウンド以上成功した後に失敗したチームを表す例外.
+
+    asyncio.gather(return_exceptions=True) の結果リストに入り、
+    _execute_impl() で team_results への追加に使われる。
+    """
+
+    def __init__(self, entry: LeaderBoardEntry, original_error: Exception) -> None:
+        self.entry = entry
+        self.original_error = original_error
+        super().__init__(
+            f"Team {entry.team_id} partially failed after {entry.round_number} round(s): {original_error}"
+        )
+
+
 class ExecutionSummary(BaseModel):
     """全チームの完了後に生成される最終集約情報
 
@@ -116,13 +131,14 @@ class ExecutionSummary(BaseModel):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def total_teams(self) -> int:
-        """総チーム数"""
-        return len(self.team_results) + len(self.failed_teams_info)
+        """総チーム数（部分成功チームの重複を排除）"""
+        all_ids = {r.team_id for r in self.team_results} | {f.team_id for f in self.failed_teams_info}
+        return len(all_ids)
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def completed_teams(self) -> int:
-        """完了チーム数"""
+        """完了チーム数（部分成功を含む）"""
         return len(self.team_results)
 
     @computed_field  # type: ignore[prop-decorator]
@@ -130,3 +146,11 @@ class ExecutionSummary(BaseModel):
     def failed_teams(self) -> int:
         """失敗チーム数"""
         return len(self.failed_teams_info)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def partial_teams(self) -> int:
+        """部分成功チーム数（成功ラウンドあり かつ 失敗あり）"""
+        success_ids = {r.team_id for r in self.team_results}
+        failed_ids = {f.team_id for f in self.failed_teams_info}
+        return len(success_ids & failed_ids)

--- a/src/mixseek/orchestrator/models.py
+++ b/src/mixseek/orchestrator/models.py
@@ -149,8 +149,14 @@ class ExecutionSummary(BaseModel):
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def partial_teams(self) -> int:
-        """部分成功チーム数（成功ラウンドあり かつ 失敗あり）"""
+    def partial_team_ids(self) -> set[str]:
+        """部分成功チームのIDセット"""
         success_ids = {r.team_id for r in self.team_results}
         failed_ids = {f.team_id for f in self.failed_teams_info}
-        return len(success_ids & failed_ids)
+        return success_ids & failed_ids
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def partial_teams(self) -> int:
+        """部分成功チーム数（成功ラウンドあり かつ 失敗あり）"""
+        return len(self.partial_team_ids)

--- a/src/mixseek/orchestrator/orchestrator.py
+++ b/src/mixseek/orchestrator/orchestrator.py
@@ -382,6 +382,7 @@ class Orchestrator:
             error_msg: エラーメッセージ
         """
         team_id = controller.get_team_id()
+        # 完了ラウンドが存在しない場合はリカバリ不可（全ラウンド失敗）
         if not controller.round_history:
             return None
         try:
@@ -389,6 +390,8 @@ class Orchestrator:
             self._write_error_to_progress_file(controller, error_msg)
             return PartialTeamFailureError(entry=entry, original_error=original_error)
         except Exception as recovery_err:
+            # リカバリはベストエフォート: DB書き込み失敗等が起きても、
+            # 呼び出し元で元のエラーが伝播するため、ここでは警告のみで抑制する
             logger.warning(f"Failed to recover partial results for {team_id}: {recovery_err}")
             return None
 

--- a/src/mixseek/orchestrator/orchestrator.py
+++ b/src/mixseek/orchestrator/orchestrator.py
@@ -459,9 +459,7 @@ class Orchestrator:
                     )
 
                     # 部分成功リカバリ: 完了ラウンドがあれば最善結果を取得
-                    partial_err = await self._try_recover_partial_failure(
-                        controller, e, "partial_failure", error_msg
-                    )
+                    partial_err = await self._try_recover_partial_failure(controller, e, "partial_failure", error_msg)
                     if partial_err is not None:
                         raise partial_err
 

--- a/src/mixseek/orchestrator/orchestrator.py
+++ b/src/mixseek/orchestrator/orchestrator.py
@@ -368,7 +368,12 @@ class Orchestrator:
         """部分成功リカバリを試行する.
 
         完了ラウンドがあれば最善結果を取得し、PartialTeamFailureErrorを返す。
-        リカバリに失敗した場合はNoneを返す。
+
+        Returns:
+            PartialTeamFailureError: 完了ラウンドがあり、リカバリに成功した場合
+            None: 以下のいずれかの場合
+                - 完了ラウンドが存在しない（round_historyが空 = 全ラウンド失敗）
+                - リカバリ処理自体が例外を投げた場合（例: DB書き込み失敗）
 
         Args:
             controller: RoundController instance

--- a/src/mixseek/orchestrator/orchestrator.py
+++ b/src/mixseek/orchestrator/orchestrator.py
@@ -388,8 +388,6 @@ class Orchestrator:
             entry = await controller._finalize_and_return_best(exit_reason, None)
             self._write_error_to_progress_file(controller, error_msg)
             return PartialTeamFailureError(entry=entry, original_error=original_error)
-        except PartialTeamFailureError as pfe:
-            return pfe
         except Exception as recovery_err:
             logger.warning(f"Failed to recover partial results for {team_id}: {recovery_err}")
             return None

--- a/src/mixseek/orchestrator/orchestrator.py
+++ b/src/mixseek/orchestrator/orchestrator.py
@@ -358,6 +358,37 @@ class Orchestrator:
 
         return summary
 
+    async def _try_recover_partial_failure(
+        self,
+        controller: RoundController,
+        original_error: Exception,
+        exit_reason: str,
+        error_msg: str,
+    ) -> PartialTeamFailureError | None:
+        """部分成功リカバリを試行する.
+
+        完了ラウンドがあれば最善結果を取得し、PartialTeamFailureErrorを返す。
+        リカバリに失敗した場合はNoneを返す。
+
+        Args:
+            controller: RoundController instance
+            original_error: 元のエラー
+            exit_reason: 終了理由
+            error_msg: エラーメッセージ
+        """
+        team_id = controller.get_team_id()
+        if not controller.round_history:
+            return None
+        try:
+            entry = await controller._finalize_and_return_best(exit_reason, None)
+            self._write_error_to_progress_file(controller, error_msg)
+            return PartialTeamFailureError(entry=entry, original_error=original_error)
+        except PartialTeamFailureError as pfe:
+            return pfe
+        except Exception as recovery_err:
+            logger.warning(f"Failed to recover partial results for {team_id}: {recovery_err}")
+            return None
+
     async def _run_team(
         self,
         controller: RoundController,
@@ -393,16 +424,11 @@ class Orchestrator:
                 logger.error(f"Team {team_id} ({team_name}) timed out: {error_msg}")
 
                 # 部分成功リカバリ: 完了ラウンドがあれば最善結果を取得
-                if controller.round_history:
-                    try:
-                        entry = await controller._finalize_and_return_best("partial_failure_timeout", None)
-                        # _finalize_and_return_best がprogressを"completed"にするので"failed"に上書き
-                        self._write_error_to_progress_file(controller, error_msg)
-                        raise PartialTeamFailureError(entry=entry, original_error=TimeoutError(error_msg))
-                    except PartialTeamFailureError:
-                        raise
-                    except Exception as recovery_err:
-                        logger.warning(f"Failed to recover partial results for {team_id}: {recovery_err}")
+                partial_err = await self._try_recover_partial_failure(
+                    controller, TimeoutError(error_msg), "partial_failure_timeout", error_msg
+                )
+                if partial_err is not None:
+                    raise partial_err
 
                 self._write_error_to_progress_file(controller, error_msg)
                 raise
@@ -433,15 +459,11 @@ class Orchestrator:
                     )
 
                     # 部分成功リカバリ: 完了ラウンドがあれば最善結果を取得
-                    if controller.round_history:
-                        try:
-                            entry = await controller._finalize_and_return_best("partial_failure", None)
-                            self._write_error_to_progress_file(controller, error_msg)
-                            raise PartialTeamFailureError(entry=entry, original_error=e)
-                        except PartialTeamFailureError:
-                            raise
-                        except Exception as recovery_err:
-                            logger.warning(f"Failed to recover partial results for {team_id}: {recovery_err}")
+                    partial_err = await self._try_recover_partial_failure(
+                        controller, e, "partial_failure", error_msg
+                    )
+                    if partial_err is not None:
+                        raise partial_err
 
                     self._write_error_to_progress_file(controller, error_msg)
                     raise

--- a/src/mixseek/orchestrator/orchestrator.py
+++ b/src/mixseek/orchestrator/orchestrator.py
@@ -23,7 +23,9 @@ except ImportError:
 from mixseek.models.leaderboard import LeaderBoardEntry
 from mixseek.orchestrator.models import (
     ExecutionSummary,
+    FailedTeamInfo,
     OrchestratorTask,
+    PartialTeamFailureError,
     TeamStatus,
 )
 
@@ -253,8 +255,6 @@ class Orchestrator:
         execution_time = time.time() - start_time
 
         # 結果収集 (Feature 037: receive LeaderBoardEntry instead of RoundResult)
-        from mixseek.orchestrator.models import FailedTeamInfo
-
         team_results: list[LeaderBoardEntry] = []
         failed_teams_info: list[FailedTeamInfo] = []
 
@@ -264,6 +264,14 @@ class Orchestrator:
                 # TeamStatus更新
                 self.team_statuses[result.team_id].status = "completed"
                 self.team_statuses[result.team_id].completed_at = result.created_at
+            elif isinstance(result, PartialTeamFailureError):
+                # 部分成功: team_results に追加（ステータスは "failed"/"timeout" のまま）
+                team_results.append(result.entry)
+                logger.info(
+                    f"Team {result.entry.team_id} partially succeeded "
+                    f"(best round: {result.entry.round_number}, score: {result.entry.score:.2f}), "
+                    f"original error: {result.original_error}"
+                )
             elif isinstance(result, Exception):
                 # Exception発生時はログのみ記録（failed_teams_infoは後で一度だけ収集）
                 logger.debug(f"Exception occurred during parallel execution: {result}")
@@ -384,9 +392,19 @@ class Orchestrator:
                 self.team_statuses[team_id].error_message = error_msg
                 logger.error(f"Team {team_id} ({team_name}) timed out: {error_msg}")
 
-                # 進捗ファイルにエラー情報を書き込む
-                self._write_error_to_progress_file(controller, error_msg)
+                # 部分成功リカバリ: 完了ラウンドがあれば最善結果を取得
+                if controller.round_history:
+                    try:
+                        entry = await controller._finalize_and_return_best("partial_failure_timeout", None)
+                        # _finalize_and_return_best がprogressを"completed"にするので"failed"に上書き
+                        self._write_error_to_progress_file(controller, error_msg)
+                        raise PartialTeamFailureError(entry=entry, original_error=TimeoutError(error_msg))
+                    except PartialTeamFailureError:
+                        raise
+                    except Exception as recovery_err:
+                        logger.warning(f"Failed to recover partial results for {team_id}: {recovery_err}")
 
+                self._write_error_to_progress_file(controller, error_msg)
                 raise
             except Exception as e:
                 error_type = type(e).__name__
@@ -414,9 +432,18 @@ class Orchestrator:
                         exc_info=True,
                     )
 
-                    # 進捗ファイルにエラー情報を書き込む
-                    self._write_error_to_progress_file(controller, error_msg)
+                    # 部分成功リカバリ: 完了ラウンドがあれば最善結果を取得
+                    if controller.round_history:
+                        try:
+                            entry = await controller._finalize_and_return_best("partial_failure", None)
+                            self._write_error_to_progress_file(controller, error_msg)
+                            raise PartialTeamFailureError(entry=entry, original_error=e)
+                        except PartialTeamFailureError:
+                            raise
+                        except Exception as recovery_err:
+                            logger.warning(f"Failed to recover partial results for {team_id}: {recovery_err}")
 
+                    self._write_error_to_progress_file(controller, error_msg)
                     raise
 
         # このコードに到達してはいけません（すべてのコードパスでreturnまたはraise）

--- a/tests/unit/cli/test_exec_exit_code.py
+++ b/tests/unit/cli/test_exec_exit_code.py
@@ -1,0 +1,243 @@
+"""mixseek exec コマンド終了コードテスト
+
+Article 3: Test-First Imperative準拠
+
+終了コード仕様:
+    - 0: 全チーム成功（failed_teams_info が空）
+    - 1: 部分成功（team_results が非空 かつ failed_teams_info が非空）
+    - 2: 全チーム失敗（team_results が空）/ 未処理例外
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from mixseek.cli.main import app
+from mixseek.models.leaderboard import LeaderBoardEntry
+from mixseek.orchestrator.models import ExecutionSummary, FailedTeamInfo
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """CLIテストランナー"""
+    return CliRunner()
+
+
+@pytest.fixture
+def orchestrator_toml(tmp_path: Path) -> Path:
+    """最小限のオーケストレータ設定TOML"""
+    team_toml = tmp_path / "team.toml"
+    team_toml.write_text("""
+[team]
+team_id = "test-team"
+team_name = "Test Team"
+
+[[team.members]]
+agent_name = "dummy"
+agent_type = "plain"
+tool_description = "dummy agent"
+model = "google-gla:gemini-2.5-flash-lite"
+system_instruction = "dummy"
+temperature = 0.7
+max_tokens = 2048
+""")
+
+    config = tmp_path / "orchestrator.toml"
+    config.write_text(f"""
+[orchestrator]
+
+[[orchestrator.teams]]
+config = "{team_toml}"
+""")
+    return config
+
+
+def _make_entry(team_id: str = "team-1", team_name: str = "Team 1") -> LeaderBoardEntry:
+    """テスト用LeaderBoardEntry生成"""
+    return LeaderBoardEntry(
+        execution_id="test-exec-id",
+        team_id=team_id,
+        team_name=team_name,
+        round_number=1,
+        submission_content="test submission",
+        score=85.0,
+        score_details={"comment": "good"},
+    )
+
+
+def _make_failed(team_id: str = "team-2", team_name: str = "Team 2") -> FailedTeamInfo:
+    """テスト用FailedTeamInfo生成"""
+    return FailedTeamInfo(
+        team_id=team_id,
+        team_name=team_name,
+        error_message="execution failed",
+    )
+
+
+def _make_summary(
+    team_results: list[LeaderBoardEntry] | None = None,
+    failed_teams_info: list[FailedTeamInfo] | None = None,
+) -> ExecutionSummary:
+    """テスト用ExecutionSummary生成"""
+    return ExecutionSummary(
+        execution_id="test-exec-id",
+        user_prompt="test prompt",
+        team_results=team_results or [],
+        failed_teams_info=failed_teams_info or [],
+        total_execution_time_seconds=1.0,
+    )
+
+
+# モック対象パス
+_EXEC_MODULE = "mixseek.cli.commands.exec"
+
+
+class TestExecExitCode:
+    """exec コマンド終了コードテスト"""
+
+    @patch(f"{_EXEC_MODULE}.close_all_auth_clients", new_callable=AsyncMock)
+    @patch(f"{_EXEC_MODULE}.setup_logfire_from_cli")
+    @patch(f"{_EXEC_MODULE}.setup_logging_from_cli")
+    @patch(f"{_EXEC_MODULE}.ConfigurationManager")
+    @patch(f"{_EXEC_MODULE}.Orchestrator")
+    @patch(f"{_EXEC_MODULE}._load_and_validate_config")
+    @patch(f"{_EXEC_MODULE}._execute_orchestration")
+    def test_all_teams_success_exit_code_0(
+        self,
+        mock_execute_orch: MagicMock,
+        mock_load_config: MagicMock,
+        mock_orchestrator_cls: MagicMock,
+        mock_config_mgr: MagicMock,
+        mock_setup_logging: MagicMock,
+        mock_setup_logfire: MagicMock,
+        mock_close_auth: AsyncMock,
+        runner: CliRunner,
+        orchestrator_toml: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """全チーム成功 → exit code 0"""
+        # Given
+        monkeypatch.setenv("MIXSEEK_WORKSPACE", str(orchestrator_toml.parent))
+        summary = _make_summary(team_results=[_make_entry()])
+        mock_execute_orch.return_value = summary
+        mock_settings = MagicMock()
+        mock_settings.teams = [MagicMock()]
+        mock_load_config.return_value = mock_settings
+
+        # When
+        result = runner.invoke(app, ["exec", "test prompt", "--config", str(orchestrator_toml)])
+
+        # Then
+        assert result.exit_code == 0
+
+    @patch(f"{_EXEC_MODULE}.close_all_auth_clients", new_callable=AsyncMock)
+    @patch(f"{_EXEC_MODULE}.setup_logfire_from_cli")
+    @patch(f"{_EXEC_MODULE}.setup_logging_from_cli")
+    @patch(f"{_EXEC_MODULE}.ConfigurationManager")
+    @patch(f"{_EXEC_MODULE}.Orchestrator")
+    @patch(f"{_EXEC_MODULE}._load_and_validate_config")
+    @patch(f"{_EXEC_MODULE}._execute_orchestration")
+    def test_partial_success_exit_code_1(
+        self,
+        mock_execute_orch: MagicMock,
+        mock_load_config: MagicMock,
+        mock_orchestrator_cls: MagicMock,
+        mock_config_mgr: MagicMock,
+        mock_setup_logging: MagicMock,
+        mock_setup_logfire: MagicMock,
+        mock_close_auth: AsyncMock,
+        runner: CliRunner,
+        orchestrator_toml: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """部分成功（成功+失敗チームあり）→ exit code 1"""
+        # Given
+        monkeypatch.setenv("MIXSEEK_WORKSPACE", str(orchestrator_toml.parent))
+        summary = _make_summary(
+            team_results=[_make_entry()],
+            failed_teams_info=[_make_failed()],
+        )
+        mock_execute_orch.return_value = summary
+        mock_settings = MagicMock()
+        mock_settings.teams = [MagicMock(), MagicMock()]
+        mock_load_config.return_value = mock_settings
+
+        # When
+        result = runner.invoke(app, ["exec", "test prompt", "--config", str(orchestrator_toml)])
+
+        # Then
+        assert result.exit_code == 1
+
+    @patch(f"{_EXEC_MODULE}.close_all_auth_clients", new_callable=AsyncMock)
+    @patch(f"{_EXEC_MODULE}.setup_logfire_from_cli")
+    @patch(f"{_EXEC_MODULE}.setup_logging_from_cli")
+    @patch(f"{_EXEC_MODULE}.ConfigurationManager")
+    @patch(f"{_EXEC_MODULE}.Orchestrator")
+    @patch(f"{_EXEC_MODULE}._load_and_validate_config")
+    @patch(f"{_EXEC_MODULE}._execute_orchestration")
+    def test_all_teams_failed_exit_code_2(
+        self,
+        mock_execute_orch: MagicMock,
+        mock_load_config: MagicMock,
+        mock_orchestrator_cls: MagicMock,
+        mock_config_mgr: MagicMock,
+        mock_setup_logging: MagicMock,
+        mock_setup_logfire: MagicMock,
+        mock_close_auth: AsyncMock,
+        runner: CliRunner,
+        orchestrator_toml: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """全チーム失敗 → exit code 2"""
+        # Given
+        monkeypatch.setenv("MIXSEEK_WORKSPACE", str(orchestrator_toml.parent))
+        summary = _make_summary(
+            team_results=[],
+            failed_teams_info=[_make_failed("team-1", "Team 1"), _make_failed("team-2", "Team 2")],
+        )
+        mock_execute_orch.return_value = summary
+        mock_settings = MagicMock()
+        mock_settings.teams = [MagicMock(), MagicMock()]
+        mock_load_config.return_value = mock_settings
+
+        # When
+        result = runner.invoke(app, ["exec", "test prompt", "--config", str(orchestrator_toml)])
+
+        # Then
+        assert result.exit_code == 2
+
+    @patch(f"{_EXEC_MODULE}.close_all_auth_clients", new_callable=AsyncMock)
+    @patch(f"{_EXEC_MODULE}.setup_logfire_from_cli")
+    @patch(f"{_EXEC_MODULE}.setup_logging_from_cli")
+    @patch(f"{_EXEC_MODULE}.ConfigurationManager")
+    @patch(f"{_EXEC_MODULE}.Orchestrator")
+    @patch(f"{_EXEC_MODULE}._load_and_validate_config")
+    @patch(f"{_EXEC_MODULE}._execute_orchestration")
+    def test_unhandled_exception_exit_code_2(
+        self,
+        mock_execute_orch: MagicMock,
+        mock_load_config: MagicMock,
+        mock_orchestrator_cls: MagicMock,
+        mock_config_mgr: MagicMock,
+        mock_setup_logging: MagicMock,
+        mock_setup_logfire: MagicMock,
+        mock_close_auth: AsyncMock,
+        runner: CliRunner,
+        orchestrator_toml: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """未処理例外 → exit code 2"""
+        # Given
+        monkeypatch.setenv("MIXSEEK_WORKSPACE", str(orchestrator_toml.parent))
+        mock_execute_orch.side_effect = RuntimeError("unexpected error")
+        mock_settings = MagicMock()
+        mock_settings.teams = [MagicMock()]
+        mock_load_config.return_value = mock_settings
+
+        # When
+        result = runner.invoke(app, ["exec", "test prompt", "--config", str(orchestrator_toml)])
+
+        # Then
+        assert result.exit_code == 2

--- a/tests/unit/cli/test_exec_exit_code.py
+++ b/tests/unit/cli/test_exec_exit_code.py
@@ -241,3 +241,85 @@ class TestExecExitCode:
 
         # Then
         assert result.exit_code == 2
+
+    @patch(f"{_EXEC_MODULE}.close_all_auth_clients", new_callable=AsyncMock)
+    @patch(f"{_EXEC_MODULE}.setup_logfire_from_cli")
+    @patch(f"{_EXEC_MODULE}.setup_logging_from_cli")
+    @patch(f"{_EXEC_MODULE}.ConfigurationManager")
+    @patch(f"{_EXEC_MODULE}.Orchestrator")
+    @patch(f"{_EXEC_MODULE}._load_and_validate_config")
+    @patch(f"{_EXEC_MODULE}._execute_orchestration")
+    def test_single_team_partial_success_exit_code_1(
+        self,
+        mock_execute_orch: MagicMock,
+        mock_load_config: MagicMock,
+        mock_orchestrator_cls: MagicMock,
+        mock_config_mgr: MagicMock,
+        mock_setup_logging: MagicMock,
+        mock_setup_logfire: MagicMock,
+        mock_close_auth: AsyncMock,
+        runner: CliRunner,
+        orchestrator_toml: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """単一チーム部分成功（R1成功, R2失敗）→ exit code 1"""
+        # Given: 同一チームが team_results と failed_teams_info の両方に存在
+        monkeypatch.setenv("MIXSEEK_WORKSPACE", str(orchestrator_toml.parent))
+        summary = _make_summary(
+            team_results=[_make_entry("team-1", "Team 1")],
+            failed_teams_info=[_make_failed("team-1", "Team 1")],
+        )
+        mock_execute_orch.return_value = summary
+        mock_settings = MagicMock()
+        mock_settings.teams = [MagicMock()]
+        mock_load_config.return_value = mock_settings
+
+        # When
+        result = runner.invoke(app, ["exec", "test prompt", "--config", str(orchestrator_toml)])
+
+        # Then
+        assert result.exit_code == 1
+
+    @patch(f"{_EXEC_MODULE}.close_all_auth_clients", new_callable=AsyncMock)
+    @patch(f"{_EXEC_MODULE}.setup_logfire_from_cli")
+    @patch(f"{_EXEC_MODULE}.setup_logging_from_cli")
+    @patch(f"{_EXEC_MODULE}.ConfigurationManager")
+    @patch(f"{_EXEC_MODULE}.Orchestrator")
+    @patch(f"{_EXEC_MODULE}._load_and_validate_config")
+    @patch(f"{_EXEC_MODULE}._execute_orchestration")
+    def test_mixed_full_partial_failure_exit_code_1(
+        self,
+        mock_execute_orch: MagicMock,
+        mock_load_config: MagicMock,
+        mock_orchestrator_cls: MagicMock,
+        mock_config_mgr: MagicMock,
+        mock_setup_logging: MagicMock,
+        mock_setup_logfire: MagicMock,
+        mock_close_auth: AsyncMock,
+        runner: CliRunner,
+        orchestrator_toml: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Team A全成功 + Team B部分失敗 + Team C完全失敗 → exit code 1"""
+        # Given
+        monkeypatch.setenv("MIXSEEK_WORKSPACE", str(orchestrator_toml.parent))
+        summary = _make_summary(
+            team_results=[
+                _make_entry("team-a", "Team A"),
+                _make_entry("team-b", "Team B"),
+            ],
+            failed_teams_info=[
+                _make_failed("team-b", "Team B"),
+                _make_failed("team-c", "Team C"),
+            ],
+        )
+        mock_execute_orch.return_value = summary
+        mock_settings = MagicMock()
+        mock_settings.teams = [MagicMock(), MagicMock(), MagicMock()]
+        mock_load_config.return_value = mock_settings
+
+        # When
+        result = runner.invoke(app, ["exec", "test prompt", "--config", str(orchestrator_toml)])
+
+        # Then
+        assert result.exit_code == 1

--- a/tests/unit/orchestrator/test_models.py
+++ b/tests/unit/orchestrator/test_models.py
@@ -5,10 +5,12 @@ from pathlib import Path
 import pytest
 from pydantic_ai import RunUsage
 
+from mixseek.models.leaderboard import LeaderBoardEntry
 from mixseek.orchestrator.models import (
     ExecutionSummary,
     FailedTeamInfo,
     OrchestratorTask,
+    PartialTeamFailureError,
     RoundResult,
     TeamStatus,
 )
@@ -200,3 +202,83 @@ def test_execution_summary_with_failed_teams() -> None:
     assert summary.total_teams == 3  # 成功1 + 失敗2
     assert summary.completed_teams == 1  # 成功1
     assert summary.failed_teams == 2  # 失敗2
+    assert summary.partial_teams == 0  # 重複なし
+
+
+# =============================================================================
+# PartialTeamFailureError and partial success computed fields tests
+# =============================================================================
+
+
+def _make_leaderboard_entry(team_id: str = "team-001", team_name: str = "Test Team") -> LeaderBoardEntry:
+    """テスト用LeaderBoardEntry生成ヘルパー"""
+    return LeaderBoardEntry(
+        execution_id="test-exec-id",
+        team_id=team_id,
+        team_name=team_name,
+        round_number=1,
+        submission_content="test submission",
+        score=75.0,
+        score_details={"overall_score": 75.0},
+    )
+
+
+def test_total_teams_deduplicates_with_partial_success() -> None:
+    """同一チームが team_results と failed_teams_info の両方に入っても total_teams が重複排除される"""
+    summary = ExecutionSummary(
+        execution_id="test-exec-id",
+        user_prompt="test prompt",
+        team_results=[_make_leaderboard_entry("team-1", "Team 1")],
+        failed_teams_info=[FailedTeamInfo(team_id="team-1", team_name="Team 1", error_message="round 2 failed")],
+        total_execution_time_seconds=1.0,
+    )
+    assert summary.total_teams == 1  # 重複排除
+    assert summary.completed_teams == 1
+    assert summary.failed_teams == 1
+    assert summary.partial_teams == 1
+
+
+def test_partial_teams_count_mixed() -> None:
+    """部分成功・完全成功・完全失敗が混在する場合の partial_teams"""
+    summary = ExecutionSummary(
+        execution_id="test-exec-id",
+        user_prompt="test prompt",
+        team_results=[
+            _make_leaderboard_entry("team-a", "Team A"),  # 完全成功
+            _make_leaderboard_entry("team-b", "Team B"),  # 部分成功
+        ],
+        failed_teams_info=[
+            FailedTeamInfo(team_id="team-b", team_name="Team B", error_message="round 3 failed"),  # 部分成功
+            FailedTeamInfo(team_id="team-c", team_name="Team C", error_message="round 1 failed"),  # 完全失敗
+        ],
+        total_execution_time_seconds=1.0,
+    )
+    assert summary.total_teams == 3  # A, B, C
+    assert summary.completed_teams == 2  # A, B
+    assert summary.failed_teams == 2  # B, C
+    assert summary.partial_teams == 1  # B のみ
+
+
+def test_total_teams_no_overlap() -> None:
+    """重複がない場合の従来動作確認"""
+    summary = ExecutionSummary(
+        execution_id="test-exec-id",
+        user_prompt="test prompt",
+        team_results=[_make_leaderboard_entry("team-1", "Team 1")],
+        failed_teams_info=[FailedTeamInfo(team_id="team-2", team_name="Team 2", error_message="failed")],
+        total_execution_time_seconds=1.0,
+    )
+    assert summary.total_teams == 2
+    assert summary.partial_teams == 0
+
+
+def test_partial_team_failure_exception() -> None:
+    """PartialTeamFailureError 例外が正しいプロパティを保持する"""
+    entry = _make_leaderboard_entry("team-1", "Team 1")
+    original = RuntimeError("round 2 evaluation failed")
+    exc = PartialTeamFailureError(entry=entry, original_error=original)
+
+    assert exc.entry is entry
+    assert exc.original_error is original
+    assert "team-1" in str(exc)
+    assert "round 2 evaluation failed" in str(exc)

--- a/tests/unit/orchestrator/test_orchestrator.py
+++ b/tests/unit/orchestrator/test_orchestrator.py
@@ -1,13 +1,16 @@
 """Unit tests for Orchestrator"""
 
+from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from mixseek.agents.leader.models import MemberSubmission
 from mixseek.config.schema import OrchestratorSettings
+from mixseek.models.leaderboard import LeaderBoardEntry
 from mixseek.orchestrator import Orchestrator
+from mixseek.orchestrator.models import PartialTeamFailureError
 from mixseek.round_controller import RoundState
 
 
@@ -257,3 +260,155 @@ async def test_orchestrator_passes_on_round_complete_to_round_controller(tmp_pat
         call_kwargs = mock_rc_class.call_args.kwargs
         assert "on_round_complete" in call_kwargs
         assert call_kwargs["on_round_complete"] is dummy_callback
+
+
+# =============================================================================
+# Partial team failure recovery tests
+# =============================================================================
+
+
+def _make_mock_round_state(round_number: int = 1, score: float = 75.0) -> RoundState:
+    """テスト用RoundState生成ヘルパー"""
+    now = datetime.now(UTC)
+    return RoundState(
+        round_number=round_number,
+        submission_content="test submission",
+        evaluation_score=score,
+        score_details={"overall_score": score},
+        improvement_judgment=None,
+        round_started_at=now,
+        round_ended_at=now,
+        message_history=[],
+    )
+
+
+def _make_mock_entry(team_id: str = "test-team-001", team_name: str = "Test Team 1") -> LeaderBoardEntry:
+    """テスト用LeaderBoardEntry生成ヘルパー"""
+    now = datetime.now(UTC)
+    return LeaderBoardEntry(
+        execution_id="test-execution-id",
+        team_id=team_id,
+        team_name=team_name,
+        round_number=1,
+        submission_content="best submission",
+        score=80.0,
+        score_details={"metric1": 80.0},
+        final_submission=True,
+        exit_reason="partial_failure",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_team_partial_failure_with_round_history(tmp_path: Path) -> None:
+    """_run_team: round_history が非空の時に PartialTeamFailureError が送出される"""
+    team1_path = str(Path("tests/fixtures/team1.toml").resolve())
+
+    settings = OrchestratorSettings(
+        workspace_path=tmp_path,
+        timeout_per_team_seconds=600,
+        teams=[{"config": team1_path}],
+    )
+    orchestrator = Orchestrator(settings=settings, save_db=False)
+
+    # TeamStatus を手動登録（_execute_impl が行う初期化を模擬）
+    from mixseek.orchestrator.models import TeamStatus
+
+    orchestrator.team_statuses["test-team-001"] = TeamStatus(
+        team_id="test-team-001",
+        team_name="Test Team 1",
+    )
+
+    # Mock controller
+    mock_controller = MagicMock()
+    mock_controller.get_team_id.return_value = "test-team-001"
+    mock_controller.get_team_name.return_value = "Test Team 1"
+    mock_controller.round_history = [_make_mock_round_state()]
+
+    # run_round が例外を送出
+    mock_controller.run_round = AsyncMock(side_effect=RuntimeError("evaluator API error"))
+
+    # _finalize_and_return_best が最善結果を返す
+    mock_entry = _make_mock_entry()
+    mock_controller._finalize_and_return_best = AsyncMock(return_value=mock_entry)
+
+    # _write_progress_file のモック
+    mock_controller._write_progress_file = MagicMock()
+
+    # When
+    with pytest.raises(PartialTeamFailureError) as exc_info:
+        await orchestrator._run_team(mock_controller, "test prompt", 600)
+
+    # Then
+    assert exc_info.value.entry is mock_entry
+    assert isinstance(exc_info.value.original_error, RuntimeError)
+    assert orchestrator.team_statuses["test-team-001"].status == "failed"
+    mock_controller._finalize_and_return_best.assert_awaited_once_with("partial_failure", None)
+
+
+@pytest.mark.asyncio
+async def test_run_team_no_round_history_raises_original(tmp_path: Path) -> None:
+    """_run_team: round_history が空の場合は元の例外がそのまま送出される"""
+    team1_path = str(Path("tests/fixtures/team1.toml").resolve())
+
+    settings = OrchestratorSettings(
+        workspace_path=tmp_path,
+        timeout_per_team_seconds=600,
+        teams=[{"config": team1_path}],
+    )
+    orchestrator = Orchestrator(settings=settings, save_db=False)
+
+    from mixseek.orchestrator.models import TeamStatus
+
+    orchestrator.team_statuses["test-team-001"] = TeamStatus(
+        team_id="test-team-001",
+        team_name="Test Team 1",
+    )
+
+    mock_controller = MagicMock()
+    mock_controller.get_team_id.return_value = "test-team-001"
+    mock_controller.get_team_name.return_value = "Test Team 1"
+    mock_controller.round_history = []  # 空: ラウンド0で失敗
+    mock_controller.run_round = AsyncMock(side_effect=RuntimeError("immediate failure"))
+    mock_controller._write_progress_file = MagicMock()
+
+    with pytest.raises(RuntimeError, match="immediate failure"):
+        await orchestrator._run_team(mock_controller, "test prompt", 600)
+
+    assert orchestrator.team_statuses["test-team-001"].status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_execute_impl_handles_partial_team_failure(tmp_path: Path) -> None:
+    """_execute_impl: PartialTeamFailureError が team_results と failed_teams_info の両方に入る"""
+    team1_path = str(Path("tests/fixtures/team1.toml").resolve())
+
+    settings = OrchestratorSettings(
+        workspace_path=tmp_path,
+        timeout_per_team_seconds=600,
+        teams=[{"config": team1_path}],
+    )
+    orchestrator = Orchestrator(settings=settings, save_db=False)
+
+    mock_entry = _make_mock_entry()
+
+    with patch("mixseek.round_controller.RoundController") as mock_rc_class:
+        mock_rc = MagicMock()
+        mock_rc.get_team_id.return_value = "test-team-001"
+        mock_rc.get_team_name.return_value = "Test Team 1"
+        mock_rc.round_history = [_make_mock_round_state()]
+        mock_rc.run_round = AsyncMock(side_effect=RuntimeError("round 2 failed"))
+        mock_rc._finalize_and_return_best = AsyncMock(return_value=mock_entry)
+        mock_rc._write_progress_file = MagicMock()
+        mock_rc_class.return_value = mock_rc
+
+        summary = await orchestrator.execute(user_prompt="Test prompt", timeout_seconds=300)
+
+    # team_results と failed_teams_info の両方に同一チームが入る
+    assert len(summary.team_results) == 1
+    assert summary.team_results[0].team_id == "test-team-001"
+    assert len(summary.failed_teams_info) == 1
+    assert summary.failed_teams_info[0].team_id == "test-team-001"
+    assert summary.total_teams == 1  # 重複排除
+    assert summary.partial_teams == 1


### PR DESCRIPTION
## Summary

- `mixseek exec` コマンドの終了コードをチーム実行結果に応じて分岐するように修正
  - **0**: 全チーム成功（`failed_teams_info` が空）
  - **1**: 部分成功（成功チームあり + 失敗チームあり）
  - **2**: 全チーム失敗（`team_results` が空）/ 未処理例外
- 既存の `except Exception` で一律 exit code 1 を返していた箇所を exit code 2 に変更
- `typer.Exit` が `Exception` のサブクラスであるため、`except typer.Exit: raise` を追加して再ラップを防止

## Test plan

- [x] 全チーム成功 → exit code 0
- [x] 部分成功 → exit code 1
- [x] 全チーム失敗 → exit code 2
- [x] 未処理例外 → exit code 2
- [x] 既存テスト（test_exec_logfire.py）退行なし
- [x] ruff check / ruff format / mypy 全パス

## Errors encountered during implementation

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)