### PR TITLE
feat(workflow): function plugin に path ロード方式を追加

### DIFF
--- a/src/mixseek/config/schema.py
+++ b/src/mixseek/config/schema.py
@@ -1194,12 +1194,17 @@ class FunctionPluginMetadata(BaseModel):
 
     Note:
         agent 用 `PluginMetadata` は流用不可（フィールド不一致 + extra=forbid）。
-        `module` / `function` のみを持つ軽量構造。
+        `module` / `path` / `function` のみを持つ軽量構造。
+        `module` と `path` は排他で、いずれか一方を必ず指定する必要がある。
     """
 
-    module: str = Field(
-        ...,
-        description="Python module path（例: 'mypackage.formatters'）",
+    module: str | None = Field(
+        default=None,
+        description="Python module path（sys.path 経由、例: 'mypackage.formatters'）",
+    )
+    path: str | None = Field(
+        default=None,
+        description="Python ファイルパス（絶対 path 推奨、相対は cwd 起点で解釈）",
     )
     function: str = Field(
         ...,
@@ -1210,6 +1215,19 @@ class FunctionPluginMetadata(BaseModel):
         extra="forbid",
         str_strip_whitespace=True,
     )
+
+    @model_validator(mode="after")
+    def _validate_module_path_exclusive(self) -> "FunctionPluginMetadata":
+        """`module` と `path` の排他制約を検証する。
+
+        - 両方 None: ロード元が決まらないため不正
+        - 両方指定: try-then-fallback の意味が薄く TOML の読みにくさを招くため禁止
+        """
+        if self.module is None and self.path is None:
+            raise ValueError("FunctionPluginMetadata は 'module' または 'path' のいずれかが必須です")
+        if self.module is not None and self.path is not None:
+            raise ValueError("FunctionPluginMetadata の 'module' と 'path' は同時指定できません（排他）")
+        return self
 
 
 class AgentExecutorSettings(MixSeekBaseSettings):

--- a/src/mixseek/workflow/executable.py
+++ b/src/mixseek/workflow/executable.py
@@ -317,13 +317,16 @@ def _load_module_from_path(path: str) -> Any:
     member 側 `custom_agent_<hash>` と同居しても衝突しないよう `custom_function_` プレフィックスを使う。
 
     Raises:
-        ValueError: file 不在 / spec 生成失敗 / モジュールレベルコードの実行失敗
+        ValueError: file 不在 / 通常ファイル以外（ディレクトリ等） / spec 生成失敗 /
+            モジュールレベルコードの実行失敗
     """
     path_obj = Path(path)
-    if not path_obj.exists():
+    # ディレクトリを誤って渡された場合 `spec_from_file_location` は spec=None を返し
+    # 「Failed to create module spec」という不透明なエラーになるため、is_file() で先に弾く。
+    if not path_obj.is_file():
         raise ValueError(
             f"Failed to load function from path '{path}'. "
-            f"FileNotFoundError: File not found. Check file path in TOML config."
+            f"FileNotFoundError: File not found or is not a regular file. Check file path in TOML config."
         )
 
     path_hash = hashlib.sha256(str(path_obj.resolve()).encode()).hexdigest()[:16]

--- a/src/mixseek/workflow/executable.py
+++ b/src/mixseek/workflow/executable.py
@@ -15,8 +15,11 @@ logfire はオプション依存のため、未導入環境では `_logfire_span
 """
 
 import asyncio
+import hashlib
 import importlib
+import importlib.util
 import logging
+import sys
 import time
 from collections.abc import Awaitable, Callable
 from contextlib import AbstractContextManager, nullcontext
@@ -284,10 +287,15 @@ def build_executable(
     Raises:
         TypeError: 未知の cfg 型
         ValueError: function の module/attribute import 失敗
-            （`WorkflowEngine._execute_step` で `WorkflowStepFailedError` に昇格）
+            （`WorkflowEngine._execute_step` で `WorkflowStepFailedError` に昇格）。
+            `path` 指定時の file 不在 / spec 生成失敗も同じく `ValueError` に正規化される。
     """
     if isinstance(cfg, FunctionExecutorSettings):
-        func = _load_function(cfg.plugin.module, cfg.plugin.function)
+        func = _load_function(
+            module=cfg.plugin.module,
+            path=cfg.plugin.path,
+            function=cfg.plugin.function,
+        )
         return FunctionExecutable(
             name=cfg.name,
             func=func,
@@ -301,19 +309,82 @@ def build_executable(
     raise TypeError(f"Unsupported executor config: {type(cfg).__name__}")
 
 
-def _load_function(module: str, function: str) -> Callable[[str], Any]:
-    """`module.function` を動的解決して callable を返す。
+def _load_module_from_path(path: str) -> Any:
+    """指定 file path から Python module を読み込む（member の load_agent_from_path 同等）。
+
+    `path` は絶対 path 推奨。相対 path は cwd 起点で解釈される（member 側と同じ挙動）。
+    sys.modules には絶対 path の sha256 ハッシュ前 16 文字を suffix にした module 名で登録し、
+    member 側 `custom_agent_<hash>` と同居しても衝突しないよう `custom_function_` プレフィックスを使う。
 
     Raises:
-        ValueError: module import 失敗 / attribute 不在 / callable でない
+        ValueError: file 不在 / spec 生成失敗 / モジュールレベルコードの実行失敗
     """
+    path_obj = Path(path)
+    if not path_obj.exists():
+        raise ValueError(
+            f"Failed to load function from path '{path}'. "
+            f"FileNotFoundError: File not found. Check file path in TOML config."
+        )
+
+    path_hash = hashlib.sha256(str(path_obj.resolve()).encode()).hexdigest()[:16]
+    module_name = f"custom_function_{path_hash}"
+
+    spec = importlib.util.spec_from_file_location(module_name, path_obj)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"Failed to create module spec from path '{path}'.")
+
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    # SECURITY: モジュールレベルコードが実行されるため信頼できるソースのみ使用すること。
+    # member 側 `load_agent_from_path` と同じ制約。
     try:
-        mod = importlib.import_module(module)
-    except ImportError as e:
-        raise ValueError(f"Failed to import module '{module}': {e}") from e
+        spec.loader.exec_module(mod)
+    except Exception as e:
+        # モジュールレベルコード実行時の任意例外を ValueError に正規化（docstring の Raises 契約）。
+        # 不完全な module オブジェクトを sys.modules に残さないよう除去する。
+        sys.modules.pop(module_name, None)
+        raise ValueError(f"Failed to execute module from path '{path}': {e}") from e
+    return mod
+
+
+def _load_function(
+    *,
+    module: str | None,
+    path: str | None,
+    function: str,
+) -> Callable[[str], Any]:
+    """`function` を `module` (importlib) または `path` (file-based) から動的解決して返す。
+
+    `module` / `path` の排他制約は upstream の
+    `FunctionPluginMetadata._validate_module_path_exclusive` で検証済み。
+    本関数は upstream を迂回した呼び出しに備えて「両方 None」と「両方指定」の双方を
+    防御的にガードする。
+
+    Raises:
+        ValueError:
+            - module import 失敗
+            - path 指定時の file 不在 / spec 生成失敗 / モジュール実行失敗
+            - attribute 不在 / callable でない
+            - module / path 両方 None
+            - module / path 両方指定（排他制約違反）
+    """
+    if module is not None and path is not None:
+        raise ValueError("Cannot specify both 'module' and 'path' (mutually exclusive)")
+    if path is not None:
+        mod = _load_module_from_path(path)
+        source_label = f"path '{path}'"
+    elif module is not None:
+        try:
+            mod = importlib.import_module(module)
+        except ImportError as e:
+            raise ValueError(f"Failed to import module '{module}': {e}") from e
+        source_label = f"module '{module}'"
+    else:
+        raise ValueError("Either 'module' or 'path' must be specified")
+
     if not hasattr(mod, function):
-        raise ValueError(f"Module '{module}' has no attribute '{function}'")
+        raise ValueError(f"{source_label.capitalize()} has no attribute '{function}'")
     fn: Callable[[str], Any] = getattr(mod, function)
     if not callable(fn):
-        raise ValueError(f"'{module}.{function}' is not callable")
+        raise ValueError(f"'{function}' in {source_label} is not callable")
     return fn

--- a/tests/integration/test_workflow_function_path.py
+++ b/tests/integration/test_workflow_function_path.py
@@ -1,0 +1,84 @@
+"""Workflow Function Plugin の `path` ロード方式 配線確認 integration test。
+
+PR4.5 で追加された `FunctionPluginMetadata.path` 経由での function executor 構築・実行を、
+TOML → `ConfigurationManager.load_workflow_settings` → `build_executable` → `Executable.run`
+の end-to-end で 1 本のみ確認する。
+
+`WorkflowEngine` 全体は本ファイルでは扱わない（PR5 で別途 end-to-end をカバーする）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from mixseek.agents.leader.dependencies import TeamDependencies
+from mixseek.config import ConfigurationManager
+from mixseek.config.schema import FunctionExecutorSettings
+from mixseek.workflow.executable import FunctionExecutable, build_executable
+
+
+@pytest.fixture
+def team_deps() -> TeamDependencies:
+    """integration テストローカルの `TeamDependencies`（unit 側 conftest は参照不可）。"""
+    return TeamDependencies(
+        execution_id="exec-pr4-5",
+        team_id="fn-path-integration",
+        team_name="Integration Test",
+        round_number=1,
+    )
+
+
+@pytest.mark.integration
+def test_workflow_function_path_loading_end_to_end(
+    tmp_path: Path,
+    team_deps: TeamDependencies,
+) -> None:
+    """workflow TOML（`path` 指定）→ load → build_executable → run の配線確認。
+
+    `path` は **絶対 path** で TOML に書き込む（member 流の挙動踏襲のため、
+    workspace 起点解決はしない）。`tmp_path` 経由で再現性を担保する。
+    """
+    # 1. function file を配置（絶対 path で参照される）
+    fn_file = tmp_path / "formatters.py"
+    fn_file.write_text(
+        "def to_upper(x: str) -> str:\n    return x.upper()\n",
+        encoding="utf-8",
+    )
+
+    # 2. workflow TOML を書き出し（path には絶対 path を埋め込む）
+    toml_path = tmp_path / "workflow.toml"
+    toml_path.write_text(
+        "[workflow]\n"
+        'workflow_id = "fn-path-integration"\n'
+        'workflow_name = "fn-path-integration"\n'
+        'default_model = "google-gla:gemini-2.5-flash"\n'
+        "[[workflow.steps]]\n"
+        'id = "s1"\n'
+        "[[workflow.steps.executors]]\n"
+        'name = "upper"\n'
+        'type = "function"\n'
+        "[workflow.steps.executors.plugin]\n"
+        f'path = "{fn_file}"\n'
+        'function = "to_upper"\n',
+        encoding="utf-8",
+    )
+
+    # 3. ConfigurationManager で読み込み
+    cm = ConfigurationManager(workspace=tmp_path)
+    wf_settings = cm.load_workflow_settings(toml_path)
+    fn_cfg = wf_settings.steps[0].executors[0]
+    assert isinstance(fn_cfg, FunctionExecutorSettings)
+    assert fn_cfg.plugin.path == str(fn_file)
+    assert fn_cfg.plugin.module is None
+
+    # 4. build_executable で executable 生成
+    executable = build_executable(fn_cfg, team_deps, default_model=wf_settings.default_model)
+    assert isinstance(executable, FunctionExecutable)
+
+    # 5. 実行（function 単体の async 経路を確認）
+    result = asyncio.run(executable.run("hello"))
+    assert result.status == "SUCCESS"
+    assert result.content == "HELLO"

--- a/tests/unit/config/test_workflow_settings.py
+++ b/tests/unit/config/test_workflow_settings.py
@@ -79,9 +79,22 @@ class TestFunctionPluginMetadata:
         meta = FunctionPluginMetadata(module="mypkg.tools", function="format_as_markdown")
         assert meta.module == "mypkg.tools"
         assert meta.function == "format_as_markdown"
+        assert meta.path is None
 
-    def test_missing_module_raises(self) -> None:
-        with pytest.raises(ValidationError):
+    def test_path_only_valid(self) -> None:
+        """`path` のみ指定で作成成功（module は None）。"""
+        meta = FunctionPluginMetadata(path="/abs/path/formatters.py", function="fmt")
+        assert meta.path == "/abs/path/formatters.py"
+        assert meta.module is None
+
+    def test_both_module_and_path_raises(self) -> None:
+        """`module` と `path` の同時指定はエラー（排他制約）。"""
+        with pytest.raises(ValidationError, match="同時指定できません"):
+            FunctionPluginMetadata(module="m", path="/p", function="f")
+
+    def test_neither_module_nor_path_raises(self) -> None:
+        """`module` / `path` どちらも指定しないとエラー（必須制約）。"""
+        with pytest.raises(ValidationError, match="のいずれかが必須"):
             FunctionPluginMetadata.model_validate({"function": "fn"})
 
     def test_missing_function_raises(self) -> None:
@@ -98,6 +111,11 @@ class TestFunctionPluginMetadata:
         meta = FunctionPluginMetadata(module="  mypkg  ", function="  fn  ")
         assert meta.module == "mypkg"
         assert meta.function == "fn"
+
+    def test_path_str_strip_whitespace(self) -> None:
+        """`path` フィールドにも str_strip_whitespace=True が適用される。"""
+        meta = FunctionPluginMetadata(path="  /abs/path/formatters.py  ", function="fmt")
+        assert meta.path == "/abs/path/formatters.py"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflow/test_executable_builder.py
+++ b/tests/unit/workflow/test_executable_builder.py
@@ -166,6 +166,14 @@ class TestLoadFunction:
                 function="fn",
             )
 
+    def test_path_is_directory(self, tmp_path: Path) -> None:
+        """`path` がディレクトリを指す場合、`spec_from_file_location` 失敗による
+        不透明なエラーではなく、is_file() バリデーションで ValueError として弾く。"""
+        d = tmp_path / "not_a_file"
+        d.mkdir()
+        with pytest.raises(ValueError, match="FileNotFoundError"):
+            _load_function(module=None, path=str(d), function="fn")
+
     def test_path_attribute_not_found(self, tmp_path: Path) -> None:
         """`path` ロードに成功しても function 名が無ければ ValueError。"""
         f = tmp_path / "mod.py"

--- a/tests/unit/workflow/test_executable_builder.py
+++ b/tests/unit/workflow/test_executable_builder.py
@@ -6,6 +6,7 @@ invariant:
 """
 
 from contextlib import nullcontext
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -109,24 +110,113 @@ class TestBuildExecutable:
                 default_model="google-gla:gemini-2.5-flash",
             )
 
+    def test_function_settings_with_path(self, team_deps: TeamDependencies, tmp_path: Path) -> None:
+        """`path` 経由の FunctionPluginMetadata でも build_executable が通る。"""
+        from mixseek.config.schema import FunctionExecutorSettings, FunctionPluginMetadata
+
+        f = tmp_path / "fmt.py"
+        f.write_text("def fn(x):\n    return f'P:{x}'\n", encoding="utf-8")
+        cfg = FunctionExecutorSettings(
+            name="fn",
+            plugin=FunctionPluginMetadata(path=str(f), function="fn"),
+            timeout_seconds=5,
+        )
+        ex = build_executable(cfg, team_deps, default_model="google-gla:gemini-2.5-flash")
+        assert isinstance(ex, FunctionExecutable)
+        assert ex.name == "fn"
+        assert ex.executor_type == "function"
+
 
 class TestLoadFunction:
     def test_module_not_found(self) -> None:
         with pytest.raises(ValueError, match="Failed to import module"):
-            _load_function("no_such_module_xyz_abc", "foo")
+            _load_function(module="no_such_module_xyz_abc", path=None, function="foo")
 
     def test_attribute_not_found(self) -> None:
         with pytest.raises(ValueError, match="has no attribute"):
-            _load_function("tests.unit.workflow._executable_helpers", "nonexistent_attr")
+            _load_function(
+                module="tests.unit.workflow._executable_helpers",
+                path=None,
+                function="nonexistent_attr",
+            )
 
     def test_not_callable(self) -> None:
         with pytest.raises(ValueError, match="is not callable"):
             _load_function(
-                "tests.unit.workflow._executable_helpers",
-                "sample_non_callable",
+                module="tests.unit.workflow._executable_helpers",
+                path=None,
+                function="sample_non_callable",
             )
 
     def test_callable_returned(self) -> None:
-        fn = _load_function("tests.unit.workflow._executable_helpers", "sample_function")
+        fn = _load_function(
+            module="tests.unit.workflow._executable_helpers",
+            path=None,
+            function="sample_function",
+        )
         assert callable(fn)
         assert fn("x") == "sample: x"
+
+    def test_path_file_not_found(self, tmp_path: Path) -> None:
+        """`path` 指定時に file が存在しないと ValueError。"""
+        with pytest.raises(ValueError, match="FileNotFoundError"):
+            _load_function(
+                module=None,
+                path=str(tmp_path / "nonexistent.py"),
+                function="fn",
+            )
+
+    def test_path_attribute_not_found(self, tmp_path: Path) -> None:
+        """`path` ロードに成功しても function 名が無ければ ValueError。"""
+        f = tmp_path / "mod.py"
+        f.write_text("def existing(x):\n    return x\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="has no attribute"):
+            _load_function(module=None, path=str(f), function="missing")
+
+    def test_path_not_callable(self, tmp_path: Path) -> None:
+        """`path` 内に非 callable な属性しかなければ ValueError。"""
+        f = tmp_path / "mod.py"
+        f.write_text("VALUE = 42\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="is not callable"):
+            _load_function(module=None, path=str(f), function="VALUE")
+
+    def test_path_callable_returned(self, tmp_path: Path) -> None:
+        """絶対 path 経由で正しく callable が取得できる正常系。"""
+        f = tmp_path / "mod.py"
+        f.write_text("def fn(x):\n    return f'path: {x}'\n", encoding="utf-8")
+        out = _load_function(module=None, path=str(f), function="fn")
+        assert callable(out)
+        assert out("hello") == "path: hello"
+
+    def test_path_module_exec_failure(self, tmp_path: Path) -> None:
+        """path 経由でモジュールレベルコードが例外を出した場合に ValueError へ正規化される。
+
+        失敗時に不完全な module オブジェクトが `sys.modules` に残らないことも確認する
+        （次回 import 時にキャッシュ汚染を引き起こさないよう_load_module_from_path で
+        `sys.modules.pop` している契約）。
+        """
+        import hashlib
+        import sys as _sys
+
+        f = tmp_path / "mod.py"
+        f.write_text("raise RuntimeError('boom at import time')\n", encoding="utf-8")
+        path_hash = hashlib.sha256(str(f.resolve()).encode()).hexdigest()[:16]
+        module_name = f"custom_function_{path_hash}"
+        _sys.modules.pop(module_name, None)  # 念のため事前クリア（並列テスト耐性）
+
+        with pytest.raises(ValueError, match="Failed to execute module from path"):
+            _load_function(module=None, path=str(f), function="fn")
+
+        assert module_name not in _sys.modules, f"failed module '{module_name}' must be cleaned up from sys.modules"
+
+    def test_both_module_and_path_raises(self, tmp_path: Path) -> None:
+        """upstream を迂回した呼び出しで module / path 両方指定された場合、防御的に ValueError。"""
+        f = tmp_path / "mod.py"
+        f.write_text("def fn(x):\n    return x\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            _load_function(module="some.module", path=str(f), function="fn")
+
+    def test_neither_module_nor_path_raises(self) -> None:
+        """upstream を迂回した呼び出しで両方 None の場合、防御的に ValueError。"""
+        with pytest.raises(ValueError, match="Either 'module' or 'path'"):
+            _load_function(module=None, path=None, function="fn")


### PR DESCRIPTION
## Summary

- `FunctionPluginMetadata` に `path` フィールドを追加し、`module` (sys.path 経由) / `path` (file path 直接ロード) の排他指定で function executor のロード元を選択できるようにした。
- `_load_module_from_path` を新設し、member agent の `load_agent_from_path` と対称な挙動 (sha256 ベースの module 名・SECURITY 警告コメント) を実装。`exec_module` の任意例外を `ValueError` へ正規化し、不完全な module は `sys.modules` から除去する。
- `_load_function` を kwargs-only に変更し、path/module 双方の経路と防御的ガード (両方 None / 両方指定) を追加。`build_executable` も新シグネチャに合わせて更新。
- 既存 `module` 経路のエラーメッセージ (`Failed to import module` / `has no attribute` / `is not callable`) は完全互換を維持。
- 計画書: [.logs/plans/pr4-5-glowing-pebble.md](.logs/plans/pr4-5-glowing-pebble.md)

## 変更ファイル

| 種別 | ファイル | 内容 |
|---|---|---|
| Modified | `src/mixseek/config/schema.py` | `FunctionPluginMetadata` に `path` 追加 + 排他バリデータ |
| Modified | `src/mixseek/workflow/executable.py` | `_load_module_from_path` 追加・`_load_function` kwargs 化 |
| Modified | `tests/unit/config/test_workflow_settings.py` | `TestFunctionPluginMetadata` に 4 ケース追加・`test_missing_module_raises` を `test_neither_module_nor_path_raises` に置換 |
| Modified | `tests/unit/workflow/test_executable_builder.py` | `TestLoadFunction` を kwargs 化 + 7 ケース追加、`TestBuildExecutable` に `test_function_settings_with_path` 追加 |
| Added | `tests/integration/test_workflow_function_path.py` | TOML → load → build_executable → run の配線確認 |

## Test plan

- [x] `make -C dockerfiles/ci lint format-check type-check test-fast` 全通 (1726 passed / 26 skipped)
- [x] `tests/unit/config/test_workflow_settings.py::TestFunctionPluginMetadata` 8 ケース全 pass
- [x] `tests/unit/workflow/test_executable_builder.py::TestLoadFunction` 11 ケース全 pass
- [x] `tests/unit/workflow/test_executable_builder.py::TestBuildExecutable::test_function_settings_with_path` pass
- [x] `tests/integration/test_workflow_function_path.py` pass
- [x] copilot による実装/テストレビューで本質的指摘なしを確認

## 作業時に遭遇したツール実行エラーと対処結果

| エラー | 対処 |
|---|---|
| `make format-check` で `tests/unit/workflow/test_executable_builder.py` のフォーマット違反 (assert メッセージの折り返し起因) | `uv run ruff format` で再整形して解決 |
| copilot レビュー指摘: `_load_module_from_path` で `spec.loader.exec_module` の例外が `ValueError` に正規化されない | try/except で wrap し `ValueError` に変換、`sys.modules.pop(module_name, None)` で不完全 module をクリーンアップ |
| copilot レビュー指摘: `_load_function` に排他制約 (両方指定) の防御的ガードが不足 | 関数先頭に `if module is not None and path is not None: raise ValueError("Cannot specify both 'module' and 'path' (mutually exclusive)")` を追加 |
| copilot テストレビュー指摘: `test_path_module_exec_failure` で `sys.modules` から module キーが除去される動作が未検証 | `module_name` を計算して `assert module_name not in _sys.modules` で検証 |

## PR5 への引き継ぎ

本 PR4.5 は schema + loader 拡張のみ。sample TOML / README の `path` 方式への書き換えは PR5 で実施する (計画書 §「PR5 への引き継ぎメモ」参照)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)