### PR TITLE
feat(model-settings): pydantic-ai ModelSettings/GoogleModelSettings の TOML 設定を追加

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -68,3 +68,50 @@ text = """
 | マルチターン会話 | `system_instruction` + `system_prompt` | コンテキスト維持 |
 
 参考: `references/system-prompt-vs-instructions.md`
+
+## pydantic-ai ModelSettings の透過設定 (`model_settings` / `google_model_settings`)
+
+### 概要
+
+LLM Provider 側で頻繁に追加される設定（Gemini の Thinking、Anthropic の interleaved thinking、
+OpenAI の reasoning_effort 等）に追従するため、各エージェント設定 TOML から pydantic-ai の
+`ModelSettings` / `GoogleModelSettings` (`TypedDict`) に **dict を素通し** できる経路を提供します。
+
+- mixseek-core 側では中身を検証しません（pydantic-ai が `TypedDict` を採用した設計思想に合わせる）。
+- 値のキーやフォーマット誤りは Provider API 呼び出し時のエラーで顕在化します。
+- 個別フィールド (`temperature`, `max_tokens`, `top_p`, `seed`, `stop_sequences`, `timeout_seconds`)
+  が両方設定された場合は**個別フィールドが優先**されます。
+
+### 対応エージェント
+
+`leader` / `member` / `evaluator` (`llm_default` および各 `metrics`) / `judgment`。
+プロンプトビルダーは LLM 呼び出しを持たないため対象外です。
+
+### Gemini の Thinking を有効化する例
+
+```toml
+[team.leader]
+model = "google-gla:gemini-2.5-pro"
+
+[team.leader.google_model_settings]
+google_thinking_config = { thinking_level = "HIGH", include_thoughts = true }
+```
+
+### Provider 共通設定の例
+
+```toml
+[team.leader]
+model = "openai:gpt-4o"
+
+[team.leader.model_settings]
+parallel_tool_calls = true
+extra_headers = { "x-trace-id" = "..." }
+```
+
+### 注意事項
+
+- `google_model_settings` は **Google モデル** (`google-gla:` / `google-vertex:`) のときのみ適用されます。
+  他 Provider で指定すると警告ログが出て無視されます。
+- 設定の中身は pydantic-ai のフィールド名をそのまま使用してください。
+  詳細は [pydantic-ai Thinking ドキュメント](https://pydantic.dev/docs/ai/advanced-features/thinking/)
+  および各 Provider 固有 ModelSettings のリファレンスを参照してください。

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -46,6 +46,15 @@ mixseek exec "タスク" --config orch.toml  # → 300秒（環境変数優先�
 mixseek exec "タスク" --config orch.toml  # → 120秒（TOML設定）
 ```
 
+```{admonition} `model_settings` / `google_model_settings` の合成順序
+各エージェント (`leader` / `member` / `evaluator` / `judgment`) で pydantic-ai 互換の
+`model_settings` / `google_model_settings` (dict pass-through) を指定できます。
+これらと既存の個別フィールドが両方設定された場合、構築時の合成は **後勝ち** で次の順序です:
+`model_settings` → `google_model_settings`（Google モデルのみ） → 個別フィールド (`temperature` 等)。
+個別フィールドが最優先のため、TOML の dict 内に同じキーがあっても個別フィールドが上書きします。
+詳細は [高度な機能](advanced-features.md) の「ModelSettings の透過設定」を参照。
+```
+
 ## Configuration Manager
 
 ### 基本的な使い方

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -46,14 +46,16 @@ mixseek exec "タスク" --config orch.toml  # → 300秒（環境変数優先�
 mixseek exec "タスク" --config orch.toml  # → 120秒（TOML設定）
 ```
 
-```{admonition} `model_settings` / `google_model_settings` の合成順序
+:::{admonition} model_settings / google_model_settings の合成順序
+:class: note
+
 各エージェント (`leader` / `member` / `evaluator` / `judgment`) で pydantic-ai 互換の
 `model_settings` / `google_model_settings` (dict pass-through) を指定できます。
 これらと既存の個別フィールドが両方設定された場合、構築時の合成は **後勝ち** で次の順序です:
 `model_settings` → `google_model_settings`（Google モデルのみ） → 個別フィールド (`temperature` 等)。
 個別フィールドが最優先のため、TOML の dict 内に同じキーがあっても個別フィールドが上書きします。
 詳細は [高度な機能](advanced-features.md) の「ModelSettings の透過設定」を参照。
-```
+:::
 
 ## Configuration Manager
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -30,6 +30,8 @@ Leader Agentは複数のMember Agentを統括し、タスクを分配・集約�
 | stop_sequences | list[str] \| None | None | TOML/定数 | team.leader.stop_sequences | - | - | オプション | 生成を停止するシーケンスのリスト |
 | top_p | float \| None | None | TOML/定数 | team.leader.top_p | - | - | オプション | Top-pサンプリングパラメータ（0.0-1.0、Noneの場合はモデルデフォルト） |
 | seed | int \| None | None | TOML/定数 | team.leader.seed | - | - | オプション | ランダムシード（OpenAI/Geminiでサポート、Anthropicでは非サポート） |
+| model_settings | dict[str, Any] \| None | None | TOML/定数 | team.leader.model_settings | - | - | オプション | pydantic-ai `ModelSettings` (TypedDict) に素通しする dict。Provider 共通の追加設定を直接記述できる。`temperature` 等の個別フィールドが両方設定された場合は個別フィールドが優先 |
+| google_model_settings | dict[str, Any] \| None | None | TOML/定数 | team.leader.google_model_settings | - | - | オプション | pydantic-ai `GoogleModelSettings` (TypedDict) に素通しする dict。Google モデル（`google-gla:` / `google-vertex:`）のみ有効。他 Provider では警告ログを出し無視 |
 
 **設定例（TOML）**:
 ```toml
@@ -38,6 +40,15 @@ model = "openai:gpt-4o"
 system_instruction = "You are a helpful team leader coordinating multiple agents."
 temperature = 0.7
 timeout_seconds = 300
+
+# pydantic-ai ModelSettings に渡す追加設定（Provider 共通）
+[team.leader.model_settings]
+parallel_tool_calls = true
+
+# Google モデル固有設定の例（Gemini Thinking）
+# 上記 model を "google-gla:gemini-2.5-pro" 等に切り替えたときに有効化される
+[team.leader.google_model_settings]
+google_thinking_config = { thinking_level = "HIGH", include_thoughts = true }
 ```
 
 ---
@@ -61,6 +72,8 @@ Member Agentは特定のタスクを実行する専門エージェントです�
 | system_instruction | str \| None | None | TOML | agent.system_instruction | - | - | オプション | システム指示テキスト |
 | system_prompt | str \| None | None | TOML/定数 | agent.system_prompt | - | - | オプション | システムプロンプト |
 | metadata | dict[str, Any] | {} | TOML/定数 | agent.metadata | - | - | オプション | カスタムプラグイン用メタデータ |
+| model_settings | dict[str, Any] \| None | None | TOML/定数 | agent.model_settings | - | - | オプション | pydantic-ai `ModelSettings` (TypedDict) に素通しする dict。Provider 共通の追加設定。個別フィールドが両方設定された場合は個別フィールド優先 |
+| google_model_settings | dict[str, Any] \| None | None | TOML/定数 | agent.google_model_settings | - | - | オプション | pydantic-ai `GoogleModelSettings` (TypedDict) に素通しする dict。Google モデルのみ有効、他は警告のうえ無視 |
 
 **Tool設定（Web Search）**:
 
@@ -95,6 +108,14 @@ timeout = 30
 [agent.metadata]
 created_by = "user"
 version = "1.0.0"
+
+# pydantic-ai ModelSettings に渡す追加設定（Provider 共通）
+[agent.model_settings]
+parallel_tool_calls = true
+
+# Google モデル固有設定の例（Gemini Thinking）
+[agent.google_model_settings]
+google_thinking_config = { thinking_level = "HIGH", include_thoughts = true }
 ```
 
 ---
@@ -177,6 +198,8 @@ Evaluatorは複数のメトリクスを使用してAgent出力を評価します
 | stop_sequences | list[str] \| None | None | TOML/定数 | stop_sequences | - | - | オプション | 生成を停止するシーケンスのリスト |
 | top_p | float \| None | None | TOML/定数 | top_p | - | - | オプション | Top-pサンプリングパラメータ（0.0-1.0、Noneの場合はモデルデフォルト） |
 | seed | int \| None | None | TOML/定数 | seed | - | - | オプション | ランダムシード（OpenAI/Geminiでサポート、Anthropicでは非サポート） |
+| model_settings | dict[str, Any] \| None | None | TOML/定数 | model_settings | - | - | オプション | pydantic-ai `ModelSettings` (TypedDict) に素通しする dict。Provider 共通の追加設定。個別フィールド優先 |
+| google_model_settings | dict[str, Any] \| None | None | TOML/定数 | google_model_settings | - | - | オプション | pydantic-ai `GoogleModelSettings` (TypedDict) に素通しする dict。Google モデルのみ有効 |
 
 **Metrics設定**:
 
@@ -193,6 +216,8 @@ Evaluatorは複数のメトリクスを使用してAgent出力を評価します
 | metrics[].stop_sequences | list[str] \| None | None | TOML | metrics[].stop_sequences | - | - | オプション | メトリクス固有の生成停止シーケンス（Noneの場合はllm_default.stop_sequencesを使用） |
 | metrics[].top_p | float \| None | None | TOML | metrics[].top_p | - | - | オプション | メトリクス固有のTop-pサンプリング（0.0-1.0、Noneの場合はllm_default.top_pを使用） |
 | metrics[].seed | int \| None | None | TOML | metrics[].seed | - | - | オプション | メトリクス固有のランダムシード（Noneの場合はllm_default.seedを使用） |
+| metrics[].model_settings | dict[str, Any] \| None | None | TOML | metrics[].model_settings | - | - | オプション | メトリクス固有の ModelSettings pass-through dict（Noneの場合はllm_default.model_settingsを使用） |
+| metrics[].google_model_settings | dict[str, Any] \| None | None | TOML | metrics[].google_model_settings | - | - | オプション | メトリクス固有の GoogleModelSettings pass-through dict（Noneの場合はllm_default.google_model_settingsを使用） |
 
 **設定例（TOML）**:
 ```toml
@@ -218,6 +243,15 @@ weight = 0.333
 name = "Relevance"
 weight = 0.333
 model = "openai:gpt-5"  # このメトリクスだけ異なるモデルを使用
+model_settings = { extra_headers = { "x-priority" = "high" } }  # pass-through 追加設定
+
+# llm_default にも model_settings / google_model_settings を直接記述できる
+[llm_default.model_settings]
+parallel_tool_calls = true
+
+# Google モデル使用時に Thinking を有効化する例
+[llm_default.google_model_settings]
+google_thinking_config = { thinking_level = "HIGH" }
 ```
 
 ---
@@ -236,6 +270,8 @@ JudgmentはLLM-as-a-Judgeによるラウンド継続判定機能を提供しま�
 | stop_sequences | list[str] \| None | None | TOML/定数 | stop_sequences | MIXSEEK_JUDGMENT__STOP_SEQUENCES | - | オプション | 生成を停止するシーケンスのリスト |
 | top_p | float \| None | None | TOML/定数 | top_p | MIXSEEK_JUDGMENT__TOP_P | - | オプション | Top-pサンプリングパラメータ（0.0-1.0、Noneの場合はLLM側のデフォルト値） |
 | seed | int \| None | None | TOML/定数 | seed | MIXSEEK_JUDGMENT__SEED | - | オプション | ランダムシード（OpenAI/Geminiでサポート、Anthropicでは非サポート） |
+| model_settings | dict[str, Any] \| None | None | TOML/定数 | model_settings | - | - | オプション | pydantic-ai `ModelSettings` (TypedDict) に素通しする dict。Provider 共通の追加設定。個別フィールド優先 |
+| google_model_settings | dict[str, Any] \| None | None | TOML/定数 | google_model_settings | - | - | オプション | pydantic-ai `GoogleModelSettings` (TypedDict) に素通しする dict。Google モデルのみ有効 |
 | system_instruction | str \| None | None | TOML/定数 | system_instruction | MIXSEEK_JUDGMENT__SYSTEM_INSTRUCTION | - | オプション | システム指示（Noneの場合はデフォルト指示を使用） |
 | judge_on_final_round | bool | True | TOML/定数 | judge_on_final_round | MIXSEEK_JUDGMENT__JUDGE_ON_FINAL_ROUND | - | オプション | 最終ラウンド（current_round >= max_rounds）でLLM Judgementを実行するかどうか。Falseの場合、最終ラウンドではLLM呼び出しをスキップし、継続判定を直接Falseにする。次ラウンドに進めない最終ラウンドでの無意味な判定を省くことが主目的 |
 
@@ -288,6 +324,14 @@ system_instruction = """
 スコアのトレンドと提出物の品質を総合的に評価し、
 次のラウンドに進むべきかを判定してください。
 """
+
+# pydantic-ai ModelSettings に渡す追加設定（Provider 共通、検証なし）
+[model_settings]
+parallel_tool_calls = true
+
+# Google モデル固有設定の例（model を google-* 系に切り替えたとき有効化される）
+[google_model_settings]
+google_thinking_config = { thinking_level = "MEDIUM" }
 ```
 
 **環境変数設定例**:

--- a/examples/team-inline-agents.toml
+++ b/examples/team-inline-agents.toml
@@ -46,6 +46,16 @@ system_instruction = """
 model = "google-gla:gemini-2.5-flash-lite"
 temperature = 0.7  # 省略可（省略時はモデルのデフォルト値を使用）
 
+# pydantic-ai ModelSettings (TypedDict) に渡す追加設定（Provider 共通、検証なし）
+# 個別フィールド (temperature 等) が両方設定された場合は個別フィールドが優先される
+# [team.leader.model_settings]
+# parallel_tool_calls = true
+
+# Google モデル固有設定（GoogleModelSettings、Google モデル時のみ有効）
+# Gemini 2.5 系で Thinking を有効化したい場合の例
+# [team.leader.google_model_settings]
+# google_thinking_config = { thinking_level = "HIGH", include_thoughts = true }
+
 # ==========================================================================
 # Member Agent設定（インライン定義）
 # ==========================================================================

--- a/src/mixseek/agents/leader/agent.py
+++ b/src/mixseek/agents/leader/agent.py
@@ -14,12 +14,12 @@ from collections.abc import Mapping
 from typing import Any
 
 from pydantic_ai import Agent
-from pydantic_ai.settings import ModelSettings
 
 from mixseek.agents.leader.config import TeamConfig
 from mixseek.agents.leader.dependencies import TeamDependencies
 from mixseek.agents.leader.tools import register_member_tools
 from mixseek.core.auth import create_authenticated_model
+from mixseek.core.model_settings import build_model_settings
 
 DEFAULT_LEADER_SYSTEM_INSTRUCTION = """
 あなたは研究チームのリーダーエージェントです。
@@ -64,20 +64,18 @@ def create_leader_agent(team_config: TeamConfig, member_agents: Mapping[str, Any
     # 認証済みモデル作成（Vertex AI対応、DRY準拠）
     authenticated_model = create_authenticated_model(model_id)
 
-    # ModelSettings作成（全パラメータ統合）
-    model_settings: ModelSettings = {}
-    if leader_config.temperature is not None:
-        model_settings["temperature"] = leader_config.temperature
-    if leader_config.max_tokens is not None:
-        model_settings["max_tokens"] = leader_config.max_tokens
-    if leader_config.stop_sequences is not None:
-        model_settings["stop_sequences"] = leader_config.stop_sequences
-    if leader_config.top_p is not None:
-        model_settings["top_p"] = leader_config.top_p
-    if leader_config.seed is not None:
-        model_settings["seed"] = leader_config.seed
-    if leader_config.timeout_seconds is not None:
-        model_settings["timeout"] = float(leader_config.timeout_seconds)
+    # ModelSettings作成（TOML pass-through + 個別フィールドの合成）
+    model_settings = build_model_settings(
+        model_id=model_id,
+        model_settings=leader_config.model_settings,
+        google_model_settings=leader_config.google_model_settings,
+        temperature=leader_config.temperature,
+        max_tokens=leader_config.max_tokens,
+        stop_sequences=leader_config.stop_sequences,
+        top_p=leader_config.top_p,
+        seed=leader_config.seed,
+        timeout_seconds=leader_config.timeout_seconds,
+    )
 
     # retries設定を取得
     retries = leader_config.max_retries

--- a/src/mixseek/agents/leader/config.py
+++ b/src/mixseek/agents/leader/config.py
@@ -39,6 +39,16 @@ class LeaderAgentConfig(BaseModel):
     seed: int | None = Field(
         default=None, description="ランダムシード（OpenAI/Geminiでサポート、Anthropicでは非サポート）"
     )
+    model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description="pydantic-ai ModelSettings (TypedDict) に渡す dict（検証なし、Provider 共通設定）",
+    )
+    google_model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "pydantic-ai GoogleModelSettings (TypedDict) に渡す dict（Google モデルのみ有効、他は警告のうえ無視）"
+        ),
+    )
 
     @field_validator("system_instruction")
     @classmethod
@@ -85,6 +95,16 @@ class TeamMemberAgentConfig(BaseModel):
     )
     seed: int | None = Field(
         default=None, description="ランダムシード（OpenAI/Geminiでサポート、Anthropicでは非サポート）"
+    )
+    model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description="pydantic-ai ModelSettings (TypedDict) に渡す dict（検証なし、Provider 共通設定）",
+    )
+    google_model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "pydantic-ai GoogleModelSettings (TypedDict) に渡す dict（Google モデルのみ有効、他は警告のうえ無視）"
+        ),
     )
     config: str | None = Field(default=None, description="参照形式パス")
 

--- a/src/mixseek/agents/member/base.py
+++ b/src/mixseek/agents/member/base.py
@@ -10,6 +10,7 @@ from typing import Any
 from pydantic_ai.settings import ModelSettings
 
 from mixseek.agents.member.logging import MemberAgentLogger
+from mixseek.core.model_settings import build_model_settings
 from mixseek.models.member_agent import MemberAgentConfig, MemberAgentResult
 
 
@@ -71,34 +72,28 @@ class BaseMemberAgent(ABC):
     def _create_model_settings(self) -> ModelSettings:
         """Create ModelSettings from MemberAgentConfig.
 
-        Generates Pydantic AI ModelSettings from the agent configuration,
-        including temperature, max_tokens, stop_sequences, top_p, seed, and timeout.
+        TOML pass-through 設定 (model_settings / google_model_settings) と個別フィールド
+        (temperature, max_tokens, stop_sequences, top_p, seed, timeout) を合成する。
+        個別フィールドが後勝ち（最優先）。
 
         Returns:
             ModelSettings TypedDict (may be empty if no settings configured)
 
         Note:
             ModelSettings is a TypedDict with all optional fields (total=False).
-            Only non-None values from config are included in the returned dict.
-            An empty dict is a valid ModelSettings and will use model defaults.
+            空 dict も valid な ModelSettings。
 
-            The 'seed' parameter is supported by OpenAI and Gemini but not by Anthropic.
-            If using Anthropic models with seed configured, the seed will be ignored.
+            'seed' は OpenAI / Gemini でサポート、Anthropic では非サポート。
+            google_model_settings は Google モデルのみ有効、他では警告ログのうえ無視される。
         """
-        # Build ModelSettings TypedDict with only non-None values
-        settings: ModelSettings = {}
-
-        if self.config.temperature is not None:
-            settings["temperature"] = self.config.temperature
-        if self.config.max_tokens is not None:
-            settings["max_tokens"] = self.config.max_tokens
-        if self.config.stop_sequences is not None:
-            settings["stop_sequences"] = self.config.stop_sequences
-        if self.config.top_p is not None:
-            settings["top_p"] = self.config.top_p
-        if self.config.seed is not None:
-            settings["seed"] = self.config.seed
-        if self.config.timeout_seconds is not None:
-            settings["timeout"] = float(self.config.timeout_seconds)
-
-        return settings
+        return build_model_settings(
+            model_id=self.config.model,
+            model_settings=self.config.model_settings,
+            google_model_settings=self.config.google_model_settings,
+            temperature=self.config.temperature,
+            max_tokens=self.config.max_tokens,
+            stop_sequences=self.config.stop_sequences,
+            top_p=self.config.top_p,
+            seed=self.config.seed,
+            timeout_seconds=self.config.timeout_seconds,
+        )

--- a/src/mixseek/config/member_agent_loader.py
+++ b/src/mixseek/config/member_agent_loader.py
@@ -135,6 +135,8 @@ def member_settings_to_config(
         stop_sequences=settings.stop_sequences,
         top_p=settings.top_p,
         seed=settings.seed,
+        model_settings=settings.model_settings,
+        google_model_settings=settings.google_model_settings,
         system_instruction=system_instruction_text,
         system_prompt=settings.system_prompt,
         description=description,

--- a/src/mixseek/config/schema.py
+++ b/src/mixseek/config/schema.py
@@ -412,6 +412,19 @@ class LeaderAgentSettings(MixSeekBaseSettings):
         description="ランダムシード（OpenAI/Geminiでサポート、Anthropicでは非サポート）",
     )
 
+    # pydantic-ai pass-through 設定（dict のまま素通し、実行時検証なし）
+    model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description="pydantic-ai ModelSettings (TypedDict) に渡す dict（検証なし、Provider 共通設定）",
+    )
+
+    google_model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "pydantic-ai GoogleModelSettings (TypedDict) に渡す dict（Google モデルのみ有効、他は警告のうえ無視）"
+        ),
+    )
+
     @field_validator("system_instruction")
     @classmethod
     def validate_system_instruction(cls, v: str | None) -> str | None:
@@ -554,6 +567,19 @@ class MemberAgentSettings(MixSeekBaseSettings):
         description="ランダムシード（OpenAI/Geminiでサポート、Anthropicでは非サポート）",
     )
 
+    # pydantic-ai pass-through 設定（dict のまま素通し、実行時検証なし）
+    model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description="pydantic-ai ModelSettings (TypedDict) に渡す dict（検証なし、Provider 共通設定）",
+    )
+
+    google_model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "pydantic-ai GoogleModelSettings (TypedDict) に渡す dict（Google モデルのみ有効、他は警告のうえ無視）"
+        ),
+    )
+
     # Custom Agent設定（Issue #146対応）
     plugin: "PluginMetadata | None" = Field(
         default=None,
@@ -688,6 +714,19 @@ class EvaluatorSettings(MixSeekBaseSettings):
         description="ランダムシード（OpenAI/Geminiでサポート、Anthropicでは非サポート）",
     )
 
+    # pydantic-ai pass-through 設定（dict のまま素通し、実行時検証なし）
+    model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description="pydantic-ai ModelSettings (TypedDict) に渡す dict（検証なし、Provider 共通設定）",
+    )
+
+    google_model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "pydantic-ai GoogleModelSettings (TypedDict) に渡す dict（Google モデルのみ有効、他は警告のうえ無視）"
+        ),
+    )
+
     # 動的配列（TeamSettingsパターン）
     metrics: list[dict[str, Any]] = Field(
         default_factory=lambda: [
@@ -788,6 +827,19 @@ class JudgmentSettings(MixSeekBaseSettings):
     seed: int | None = Field(
         default=None,
         description="ランダムシード（OpenAI/Geminiでサポート、Anthropicでは非サポート）",
+    )
+
+    # pydantic-ai pass-through 設定（dict のまま素通し、実行時検証なし）
+    model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description="pydantic-ai ModelSettings (TypedDict) に渡す dict（検証なし、Provider 共通設定）",
+    )
+
+    google_model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "pydantic-ai GoogleModelSettings (TypedDict) に渡す dict（Google モデルのみ有効、他は警告のうえ無視）"
+        ),
     )
 
     # システムプロンプト設定（カスタマイズ可能）
@@ -1320,6 +1372,18 @@ class AgentExecutorSettings(MixSeekBaseSettings):
         description="ランダムシード（OpenAI/Geminiでサポート、Anthropicでは非サポート）",
     )
 
+    # pydantic-ai pass-through 設定（dict のまま素通し、実行時検証なし）
+    model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description="pydantic-ai ModelSettings (TypedDict) に渡す dict（検証なし、Provider 共通設定）",
+    )
+    google_model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "pydantic-ai GoogleModelSettings (TypedDict) に渡す dict（Google モデルのみ有効、他は警告のうえ無視）"
+        ),
+    )
+
     # Plugin / Tool 設定
     plugin: "PluginMetadata | None" = Field(
         default=None,
@@ -1395,6 +1459,8 @@ class AgentExecutorSettings(MixSeekBaseSettings):
             stop_sequences=self.stop_sequences,
             top_p=self.top_p,
             seed=self.seed,
+            model_settings=self.model_settings,
+            google_model_settings=self.google_model_settings,
             system_instruction=resolved_instruction,
             system_prompt=self.system_prompt,
             # description は Leader tool 登録用の説明文。workflow mode は Leader tool を介さず

--- a/src/mixseek/config/sources/evaluation_toml_source.py
+++ b/src/mixseek/config/sources/evaluation_toml_source.py
@@ -105,6 +105,11 @@ class EvaluationTomlSource(PydanticBaseSettingsSource):
             "max_tokens": llm_default.get("max_tokens"),
             "max_retries": max_retries,
             "timeout_seconds": timeout_seconds,
+            "stop_sequences": llm_default.get("stop_sequences"),
+            "top_p": llm_default.get("top_p"),
+            "seed": llm_default.get("seed"),
+            "model_settings": llm_default.get("model_settings"),
+            "google_model_settings": llm_default.get("google_model_settings"),
             # 動的配列をそのまま格納（TeamSettingsパターン）
             "metrics": data.get("metrics", []),
             "custom_metrics": data.get("custom_metrics", {}),

--- a/src/mixseek/config/sources/field_mapper.py
+++ b/src/mixseek/config/sources/field_mapper.py
@@ -62,6 +62,9 @@ def normalize_member_agent_fields(agent_data: dict[str, Any]) -> dict[str, Any]:
         "stop_sequences": agent_data.get("stop_sequences"),
         "top_p": agent_data.get("top_p"),
         "seed": agent_data.get("seed"),
+        # pydantic-ai pass-through 設定 (TypedDict)
+        "model_settings": agent_data.get("model_settings"),
+        "google_model_settings": agent_data.get("google_model_settings"),
         # カスタムAgent設定 (Issue #146)
         "plugin": agent_data.get("plugin"),
         # 直接指定を優先、未指定時はmetadata内のネスト指定を参照（後方互換性）

--- a/src/mixseek/config/sources/judgment_toml_source.py
+++ b/src/mixseek/config/sources/judgment_toml_source.py
@@ -88,6 +88,8 @@ class JudgmentTomlSource(PydanticBaseSettingsSource):
             "stop_sequences": data.get("stop_sequences"),
             "top_p": data.get("top_p"),
             "seed": data.get("seed"),
+            "model_settings": data.get("model_settings"),
+            "google_model_settings": data.get("google_model_settings"),
             "system_instruction": data.get("system_instruction"),
             "judge_on_final_round": data.get("judge_on_final_round"),
         }

--- a/src/mixseek/core/model_settings.py
+++ b/src/mixseek/core/model_settings.py
@@ -1,0 +1,106 @@
+"""pydantic-ai ModelSettings 構築ユーティリティ。
+
+TOML 設定（model_settings / google_model_settings の pass-through dict）と
+個別フィールド（temperature, max_tokens 等）を合成して pydantic-ai 互換の
+ModelSettings TypedDict を構築する。
+
+LLM Provider の進化に追従する目的で TOML 値は検証せずそのまま渡す方針。
+pydantic-ai の TypedDict 設計と同じ思想（実行時検証なし、エラーは Provider API
+呼び出し時に表面化）。
+"""
+
+import logging
+from typing import Any
+
+from pydantic_ai.settings import ModelSettings
+
+from mixseek.core.auth import AuthenticationError, AuthProvider, detect_auth_provider
+
+logger = logging.getLogger(__name__)
+
+_GOOGLE_PROVIDERS = {AuthProvider.GOOGLE_AI, AuthProvider.VERTEX_AI}
+
+
+def build_model_settings(
+    *,
+    model_id: str,
+    model_settings: dict[str, Any] | None = None,
+    google_model_settings: dict[str, Any] | None = None,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    stop_sequences: list[str] | None = None,
+    top_p: float | None = None,
+    seed: int | None = None,
+    timeout_seconds: int | float | None = None,
+) -> ModelSettings:
+    """TOML pass-through dict と個別フィールドをマージして ModelSettings を構築。
+
+    合成順序（後勝ち）:
+        1. model_settings (pydantic-ai ModelSettings TypedDict pass-through)
+        2. google_model_settings (Google モデルのときのみ重ねがけ)
+        3. 個別フィールド (temperature, max_tokens, stop_sequences, top_p, seed, timeout_seconds)
+
+    Google 以外のモデルに google_model_settings が指定されていた場合は警告を出力して無視する
+    （実行は継続）。
+
+    Args:
+        model_id: モデル識別子 (例: "google-gla:gemini-2.5-pro", "anthropic:claude-...")。
+            Provider 判定に使用する。
+        model_settings: pydantic-ai の ModelSettings TypedDict に渡す dict。
+        google_model_settings: pydantic-ai の GoogleModelSettings TypedDict に渡す dict。
+            Google モデルのときのみ適用される。
+        temperature: 個別 temperature 設定（最優先）。
+        max_tokens: 個別 max_tokens 設定（最優先）。
+        stop_sequences: 個別 stop_sequences 設定（最優先）。
+        top_p: 個別 top_p 設定（最優先）。
+        seed: 個別 seed 設定（最優先）。
+        timeout_seconds: 個別 timeout 設定（秒、最優先）。
+
+    Returns:
+        ModelSettings: マージ済み TypedDict。空 dict も valid な ModelSettings。
+
+    Note:
+        戻り値型は ModelSettings だが、Google モデルのときは GoogleModelSettings の
+        フィールド (google_thinking_config 等) を含むことがある。両者とも TypedDict
+        （実体は dict）なので pydantic-ai 側で問題なく受理される。
+    """
+    result: dict[str, Any] = {}
+
+    if model_settings:
+        result.update(model_settings)
+
+    if google_model_settings:
+        provider: AuthProvider | None
+        try:
+            provider = detect_auth_provider(model_id)
+        except AuthenticationError:
+            # 未知のプレフィックス: provider 判定不能扱いで無視
+            provider = None
+
+        if provider in _GOOGLE_PROVIDERS:
+            result.update(google_model_settings)
+        else:
+            logger.warning(
+                "google_model_settings is set but model is not a Google model; ignoring",
+                extra={
+                    "model_id": model_id,
+                    "provider": provider.value if provider is not None else "unknown",
+                },
+            )
+
+    # 個別フィールド（最優先・後勝ち）
+    if temperature is not None:
+        result["temperature"] = temperature
+    if max_tokens is not None:
+        result["max_tokens"] = max_tokens
+    if stop_sequences is not None:
+        result["stop_sequences"] = stop_sequences
+    if top_p is not None:
+        result["top_p"] = top_p
+    if seed is not None:
+        result["seed"] = seed
+    if timeout_seconds is not None:
+        result["timeout"] = float(timeout_seconds)
+
+    # TypedDict は実体が dict なので cast 不要だが、mypy 用にコメントを付ける
+    return result  # type: ignore[return-value]

--- a/src/mixseek/core/model_settings.py
+++ b/src/mixseek/core/model_settings.py
@@ -10,7 +10,7 @@ pydantic-ai の TypedDict 設計と同じ思想（実行時検証なし、エラ
 """
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from pydantic_ai.settings import ModelSettings
 
@@ -102,5 +102,6 @@ def build_model_settings(
     if timeout_seconds is not None:
         result["timeout"] = float(timeout_seconds)
 
-    # TypedDict は実体が dict なので cast 不要だが、mypy 用にコメントを付ける
-    return result  # type: ignore[return-value]
+    # TypedDict は実行時 dict なので変換コストはないが、型チェッカに対しては
+    # 明示的に ModelSettings 型へキャストする（typing.cast で意図を表現）。
+    return cast(ModelSettings, result)

--- a/src/mixseek/evaluator/evaluator.py
+++ b/src/mixseek/evaluator/evaluator.py
@@ -183,6 +183,8 @@ class Evaluator:
                     stop_sequences = config.get_stop_sequences_for_metric(metric_name)
                     top_p = config.get_top_p_for_metric(metric_name)
                     seed = config.get_seed_for_metric(metric_name)
+                    model_settings = config.get_model_settings_for_metric(metric_name)
+                    google_model_settings = config.get_google_model_settings_for_metric(metric_name)
                     # LLM-as-a-Judgeメトリクスの場合はLLMパラメータを渡す
                     score = await metric.evaluate(
                         user_query=request.user_query,
@@ -196,6 +198,8 @@ class Evaluator:
                         stop_sequences=stop_sequences,
                         top_p=top_p,
                         seed=seed,
+                        model_settings=model_settings,
+                        google_model_settings=google_model_settings,
                         prompt_builder_settings=self.prompt_builder_settings,
                         execution_id=request.execution_id,
                         team_id=request.team_id,

--- a/src/mixseek/evaluator/llm_client.py
+++ b/src/mixseek/evaluator/llm_client.py
@@ -1,12 +1,13 @@
 """Pydantic AI Agentを使用したLLMクライアントラッパー。"""
 
 import logging
+from typing import Any
 
 from pydantic import BaseModel
 from pydantic_ai import Agent
-from pydantic_ai.settings import ModelSettings
 
 from mixseek.core.auth import create_authenticated_model
+from mixseek.core.model_settings import build_model_settings
 from mixseek.evaluator.exceptions import EvaluatorAPIError
 
 logger = logging.getLogger(__name__)
@@ -24,6 +25,8 @@ async def evaluate_with_llm(
     stop_sequences: list[str] | None = None,
     top_p: float | None = None,
     seed: int | None = None,
+    model_settings: dict[str, Any] | None = None,
+    google_model_settings: dict[str, Any] | None = None,
 ) -> BaseModel:
     """構造化された出力を持つLLM-as-a-Judgeを使用して評価します。
 
@@ -101,25 +104,25 @@ async def evaluate_with_llm(
             retry_count=0,
         ) from e
 
-    # ModelSettings作成
-    model_settings = ModelSettings(temperature=temperature)
-    if max_tokens is not None:
-        model_settings["max_tokens"] = max_tokens
-    if timeout_seconds is not None:
-        model_settings["timeout"] = timeout_seconds
-    if stop_sequences is not None:
-        model_settings["stop_sequences"] = stop_sequences
-    if top_p is not None:
-        model_settings["top_p"] = top_p
-    if seed is not None:
-        model_settings["seed"] = seed
+    # ModelSettings作成（TOML pass-through + 個別フィールドの合成、個別フィールド優先）
+    merged_model_settings = build_model_settings(
+        model_id=model,
+        model_settings=model_settings,
+        google_model_settings=google_model_settings,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        stop_sequences=stop_sequences,
+        top_p=top_p,
+        seed=seed,
+        timeout_seconds=timeout_seconds,
+    )
 
     # Agent作成（構造化出力とリトライ設定）
     agent = Agent(
         authenticated_model,
         output_type=response_model,  # 構造化出力を自動的に実現
         instructions=instruction,  # システムプロンプト
-        model_settings=model_settings,  # temperature, max_tokens
+        model_settings=merged_model_settings,  # LLM設定
         retries=max_retries,  # 自動リトライ
     )
 

--- a/src/mixseek/evaluator/metrics/base.py
+++ b/src/mixseek/evaluator/metrics/base.py
@@ -1,7 +1,7 @@
 """評価メトリクスの基底メトリクスインターフェース。"""
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
@@ -209,6 +209,8 @@ class LLMJudgeMetric(BaseMetric):
         stop_sequences: list[str] | None = None,
         top_p: float | None = None,
         seed: int | None = None,
+        model_settings: dict[str, Any] | None = None,
+        google_model_settings: dict[str, Any] | None = None,
         execution_id: str | None = None,
         team_id: str | None = None,
         round_number: int | None = None,
@@ -285,6 +287,8 @@ class LLMJudgeMetric(BaseMetric):
             stop_sequences=stop_sequences,
             top_p=top_p,
             seed=seed,
+            model_settings=model_settings,
+            google_model_settings=google_model_settings,
         )
         # BaseLLMEvaluation型として扱う
         assert isinstance(raw_result, BaseLLMEvaluation)

--- a/src/mixseek/models/evaluation_config.py
+++ b/src/mixseek/models/evaluation_config.py
@@ -144,6 +144,18 @@ class MetricConfig(BaseModel):
         examples=[42, 12345],
     )
 
+    model_settings: dict[str, Any] | None = Field(
+        None,
+        description="pydantic-ai ModelSettings (TypedDict) に渡す dict（検証なし、Provider 共通設定）",
+    )
+
+    google_model_settings: dict[str, Any] | None = Field(
+        None,
+        description=(
+            "pydantic-ai GoogleModelSettings (TypedDict) に渡す dict（Google モデルのみ有効、他は警告のうえ無視）"
+        ),
+    )
+
     @field_validator("name")
     @classmethod
     def validate_name_not_empty(cls, v: str) -> str:
@@ -309,6 +321,18 @@ class LLMDefaultConfig(BaseModel):
         default=None,
         description="デフォルトランダムシード（OpenAI/Geminiでサポート、Anthropicでは非サポート）",
         examples=[42, 12345],
+    )
+
+    model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description="pydantic-ai ModelSettings (TypedDict) に渡す dict（検証なし、Provider 共通設定）",
+    )
+
+    google_model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "pydantic-ai GoogleModelSettings (TypedDict) に渡す dict（Google モデルのみ有効、他は警告のうえ無視）"
+        ),
     )
 
     @field_validator("model")
@@ -747,6 +771,30 @@ class EvaluationConfig(BaseModel):
         # フォールバック階層
         return metric.seed if metric.seed is not None else self.llm_default.seed
 
+    def get_model_settings_for_metric(self, metric_name: str) -> dict[str, Any] | None:
+        """特定のメトリクスの model_settings (pass-through dict) を取得します（フォールバックロジック）。
+
+        フォールバック階層:
+        1. メトリクスレベルの model_settings 設定
+        2. [llm_default] の model_settings 設定
+        """
+        metric = self._get_metric_config(metric_name)
+        return metric.model_settings if metric.model_settings is not None else self.llm_default.model_settings
+
+    def get_google_model_settings_for_metric(self, metric_name: str) -> dict[str, Any] | None:
+        """特定のメトリクスの google_model_settings (pass-through dict) を取得します（フォールバックロジック）。
+
+        フォールバック階層:
+        1. メトリクスレベルの google_model_settings 設定
+        2. [llm_default] の google_model_settings 設定
+        """
+        metric = self._get_metric_config(metric_name)
+        return (
+            metric.google_model_settings
+            if metric.google_model_settings is not None
+            else self.llm_default.google_model_settings
+        )
+
     model_config = {
         "json_schema_extra": {
             "examples": [
@@ -807,6 +855,8 @@ def evaluator_settings_to_evaluation_config(
         stop_sequences=evaluator_settings.stop_sequences,
         top_p=evaluator_settings.top_p,
         seed=evaluator_settings.seed,
+        model_settings=evaluator_settings.model_settings,
+        google_model_settings=evaluator_settings.google_model_settings,
     )
 
     # metrics配列をlist[dict[str, Any]]からlist[MetricConfig]に変換

--- a/src/mixseek/models/member_agent.py
+++ b/src/mixseek/models/member_agent.py
@@ -305,6 +305,18 @@ class MemberAgentConfig(BaseModel):
         description="Maximum retries for LLM API calls (passed to Agent's retries parameter, 0 means no retries)",
     )
 
+    # pydantic-ai pass-through 設定（dict のまま素通し、実行時検証なし）
+    model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description="pydantic-ai ModelSettings (TypedDict) に渡す dict（検証なし、Provider 共通設定）",
+    )
+    google_model_settings: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "pydantic-ai GoogleModelSettings (TypedDict) に渡す dict（Google モデルのみ有効、他は警告のうえ無視）"
+        ),
+    )
+
     # Instructions and behavior
     system_instruction: str | None = Field(default=None, description="Agent system instruction (str or None)")
     system_prompt: str | None = Field(

--- a/src/mixseek/round_controller/judgment_client.py
+++ b/src/mixseek/round_controller/judgment_client.py
@@ -8,13 +8,12 @@ Responsibility: Agent呼び出しとsystem_interaction生成のみ
 """
 
 import textwrap
-from typing import Any
 
 from pydantic_ai import Agent
-from pydantic_ai.settings import ModelSettings
 
 from mixseek.config.schema import JudgmentSettings
 from mixseek.core.auth import create_authenticated_model
+from mixseek.core.model_settings import build_model_settings
 from mixseek.round_controller.exceptions import JudgmentAPIError
 from mixseek.round_controller.models import ImprovementJudgment
 
@@ -87,20 +86,18 @@ class JudgmentClient:
         # 認証済みモデル作成（DRY準拠）
         authenticated_model = create_authenticated_model(self.settings.model)
 
-        # ModelSettings作成（settings から取得、None値はスキップ）
-        model_settings_dict: dict[str, Any] = {
-            "temperature": self.settings.temperature,
-            "timeout": self.settings.timeout_seconds,
-        }
-        if self.settings.max_tokens is not None:
-            model_settings_dict["max_tokens"] = self.settings.max_tokens
-        if self.settings.top_p is not None:
-            model_settings_dict["top_p"] = self.settings.top_p
-        if self.settings.stop_sequences is not None:
-            model_settings_dict["stop"] = self.settings.stop_sequences
-        if self.settings.seed is not None:
-            model_settings_dict["seed"] = self.settings.seed
-        model_settings = ModelSettings(**model_settings_dict)  # type: ignore[typeddict-item]
+        # ModelSettings作成（TOML pass-through + 個別フィールドの合成、個別フィールド優先）
+        model_settings = build_model_settings(
+            model_id=self.settings.model,
+            model_settings=self.settings.model_settings,
+            google_model_settings=self.settings.google_model_settings,
+            temperature=self.settings.temperature,
+            max_tokens=self.settings.max_tokens,
+            stop_sequences=self.settings.stop_sequences,
+            top_p=self.settings.top_p,
+            seed=self.settings.seed,
+            timeout_seconds=self.settings.timeout_seconds,
+        )
 
         # Agent作成（構造化出力とリトライ設定）
         agent = Agent(

--- a/tests/unit/test_model_settings.py
+++ b/tests/unit/test_model_settings.py
@@ -11,6 +11,7 @@ build_model_settings は TOML pass-through 設定 (model_settings / google_model
 - 未知のモデル ID（プレフィックスが不明）でも google_model_settings は無視
 """
 
+from typing import Any, cast
 from unittest.mock import patch
 
 from mixseek.core.model_settings import build_model_settings
@@ -119,14 +120,16 @@ class TestGoogleModelSettings:
             model_id="google-gla:gemini-2.5-pro",
             google_model_settings={"google_thinking_config": {"thinking_level": "HIGH"}},
         )
-        assert result["google_thinking_config"] == {"thinking_level": "HIGH"}
+        # google_thinking_config は GoogleModelSettings 固有キーのため、
+        # 戻り値型 ModelSettings には含まれない。dict として参照する。
+        assert cast(dict[str, Any], result)["google_thinking_config"] == {"thinking_level": "HIGH"}
 
     def test_google_vertex_applies_google_settings(self) -> None:
         result = build_model_settings(
             model_id="google-vertex:gemini-2.5-pro",
             google_model_settings={"google_thinking_config": {"include_thoughts": True}},
         )
-        assert result["google_thinking_config"] == {"include_thoughts": True}
+        assert cast(dict[str, Any], result)["google_thinking_config"] == {"include_thoughts": True}
 
     def test_non_google_model_warns_and_ignores(self) -> None:
         with patch("mixseek.core.model_settings.logger") as mock_logger:
@@ -173,8 +176,9 @@ class TestCombinedScenarios:
             temperature=0.0,
             max_tokens=2048,
         )
-        assert result["parallel_tool_calls"] is True
-        assert result["google_thinking_config"] == {"thinking_level": "HIGH", "include_thoughts": True}
+        as_dict = cast(dict[str, Any], result)
+        assert as_dict["parallel_tool_calls"] is True
+        assert as_dict["google_thinking_config"] == {"thinking_level": "HIGH", "include_thoughts": True}
         assert result["temperature"] == 0.0
         assert result["max_tokens"] == 2048
 

--- a/tests/unit/test_model_settings.py
+++ b/tests/unit/test_model_settings.py
@@ -1,0 +1,191 @@
+"""Unit tests for build_model_settings utility.
+
+build_model_settings は TOML pass-through 設定 (model_settings / google_model_settings) と
+個別フィールド (temperature 等) を合成して pydantic-ai 互換の ModelSettings dict を構築する。
+
+検証ポイント:
+- 空入力で空 dict を返す
+- 個別フィールドが model_settings を上書きする（後勝ち）
+- Google モデルでは google_model_settings がマージされる
+- 非 Google モデルで google_model_settings が指定された場合は警告ログ + 無視
+- 未知のモデル ID（プレフィックスが不明）でも google_model_settings は無視
+"""
+
+from unittest.mock import patch
+
+from mixseek.core.model_settings import build_model_settings
+
+
+class TestBuildModelSettingsEmpty:
+    """空入力時の挙動。"""
+
+    def test_no_inputs_returns_empty(self) -> None:
+        result = build_model_settings(model_id="google-gla:gemini-2.5-pro")
+        assert result == {}
+
+    def test_only_none_inputs_returns_empty(self) -> None:
+        result = build_model_settings(
+            model_id="anthropic:claude-sonnet-4-5",
+            model_settings=None,
+            google_model_settings=None,
+            temperature=None,
+            max_tokens=None,
+            stop_sequences=None,
+            top_p=None,
+            seed=None,
+            timeout_seconds=None,
+        )
+        assert result == {}
+
+
+class TestIndividualFields:
+    """個別フィールドのみのケース。"""
+
+    def test_all_individual_fields_set(self) -> None:
+        result = build_model_settings(
+            model_id="anthropic:claude-sonnet-4-5",
+            temperature=0.7,
+            max_tokens=1024,
+            stop_sequences=["END"],
+            top_p=0.9,
+            seed=42,
+            timeout_seconds=60,
+        )
+        assert result == {
+            "temperature": 0.7,
+            "max_tokens": 1024,
+            "stop_sequences": ["END"],
+            "top_p": 0.9,
+            "seed": 42,
+            "timeout": 60.0,
+        }
+
+    def test_timeout_seconds_converted_to_float(self) -> None:
+        result = build_model_settings(model_id="openai:gpt-4o", timeout_seconds=30)
+        assert result["timeout"] == 30.0
+        assert isinstance(result["timeout"], float)
+
+
+class TestModelSettingsPassThrough:
+    """model_settings の pass-through 動作。"""
+
+    def test_model_settings_keys_are_passed_through_verbatim(self) -> None:
+        custom = {"parallel_tool_calls": True, "extra_headers": {"x-trace": "abc"}}
+        result = build_model_settings(model_id="openai:gpt-4o", model_settings=custom)
+        assert result == custom
+
+    def test_model_settings_does_not_mutate_input(self) -> None:
+        custom = {"temperature": 0.5}
+        build_model_settings(model_id="openai:gpt-4o", model_settings=custom, temperature=0.0)
+        assert custom == {"temperature": 0.5}, "入力 dict は破壊されてはならない"
+
+
+class TestMergeOrder:
+    """合成順序（後勝ち）の検証。"""
+
+    def test_individual_field_overrides_model_settings(self) -> None:
+        result = build_model_settings(
+            model_id="anthropic:claude-sonnet-4-5",
+            model_settings={"temperature": 0.5, "max_tokens": 1000},
+            temperature=0.0,
+        )
+        assert result["temperature"] == 0.0, "個別フィールドが model_settings を上書きすべき"
+        assert result["max_tokens"] == 1000, "個別フィールドで指定されていない値は model_settings から残る"
+
+    def test_google_model_settings_overrides_model_settings_on_google(self) -> None:
+        result = build_model_settings(
+            model_id="google-gla:gemini-2.5-pro",
+            model_settings={"temperature": 0.5},
+            google_model_settings={"temperature": 0.3},
+        )
+        # google_model_settings は Google モデルのとき model_settings を上書きする
+        assert result["temperature"] == 0.3
+
+    def test_individual_field_overrides_google_model_settings(self) -> None:
+        result = build_model_settings(
+            model_id="google-gla:gemini-2.5-pro",
+            model_settings={"temperature": 0.5},
+            google_model_settings={"temperature": 0.3},
+            temperature=0.0,
+        )
+        assert result["temperature"] == 0.0, "個別フィールドは最優先"
+
+
+class TestGoogleModelSettings:
+    """google_model_settings の Provider 判定。"""
+
+    def test_google_gla_applies_google_settings(self) -> None:
+        result = build_model_settings(
+            model_id="google-gla:gemini-2.5-pro",
+            google_model_settings={"google_thinking_config": {"thinking_level": "HIGH"}},
+        )
+        assert result["google_thinking_config"] == {"thinking_level": "HIGH"}
+
+    def test_google_vertex_applies_google_settings(self) -> None:
+        result = build_model_settings(
+            model_id="google-vertex:gemini-2.5-pro",
+            google_model_settings={"google_thinking_config": {"include_thoughts": True}},
+        )
+        assert result["google_thinking_config"] == {"include_thoughts": True}
+
+    def test_non_google_model_warns_and_ignores(self) -> None:
+        with patch("mixseek.core.model_settings.logger") as mock_logger:
+            result = build_model_settings(
+                model_id="anthropic:claude-sonnet-4-5",
+                google_model_settings={"google_thinking_config": {"thinking_level": "HIGH"}},
+            )
+        assert result == {}, "非 Google モデルでは google_model_settings は無視される"
+        mock_logger.warning.assert_called_once()
+        message = mock_logger.warning.call_args[0][0]
+        assert "google_model_settings is set but model is not a Google model" in message
+
+    def test_openai_model_ignores_google_settings(self) -> None:
+        with patch("mixseek.core.model_settings.logger") as mock_logger:
+            result = build_model_settings(
+                model_id="openai:gpt-4o",
+                google_model_settings={"google_thinking_config": {}},
+            )
+        assert result == {}
+        mock_logger.warning.assert_called_once()
+
+    def test_unknown_provider_ignores_google_settings(self) -> None:
+        """未知のプレフィックスでも警告のうえ無視（実行継続）。"""
+        with patch("mixseek.core.model_settings.logger") as mock_logger:
+            result = build_model_settings(
+                model_id="unknown-provider:some-model",
+                google_model_settings={"google_thinking_config": {}},
+            )
+        assert result == {}
+        mock_logger.warning.assert_called_once()
+
+
+class TestCombinedScenarios:
+    """実利用シナリオ。"""
+
+    def test_thinking_on_google_with_individual_fields(self) -> None:
+        """Google モデルで Thinking を有効化しつつ個別 temperature/max_tokens を指定。"""
+        result = build_model_settings(
+            model_id="google-gla:gemini-2.5-pro",
+            model_settings={"parallel_tool_calls": True},
+            google_model_settings={
+                "google_thinking_config": {"thinking_level": "HIGH", "include_thoughts": True},
+            },
+            temperature=0.0,
+            max_tokens=2048,
+        )
+        assert result["parallel_tool_calls"] is True
+        assert result["google_thinking_config"] == {"thinking_level": "HIGH", "include_thoughts": True}
+        assert result["temperature"] == 0.0
+        assert result["max_tokens"] == 2048
+
+    def test_model_settings_only_on_non_google(self) -> None:
+        """Anthropic モデルで model_settings + 個別フィールド。"""
+        result = build_model_settings(
+            model_id="anthropic:claude-sonnet-4-5",
+            model_settings={"extra_headers": {"anthropic-beta": "interleaved-thinking-2025-05-14"}},
+            temperature=0.5,
+            max_tokens=4096,
+        )
+        assert result["extra_headers"] == {"anthropic-beta": "interleaved-thinking-2025-05-14"}
+        assert result["temperature"] == 0.5
+        assert result["max_tokens"] == 4096


### PR DESCRIPTION
## Summary

各エージェント (Leader / Member / Evaluator / Judgment) の TOML 設定に pydantic-ai の `ModelSettings` / `GoogleModelSettings` (TypedDict) へ dict を素通しできる `model_settings` / `google_model_settings` フィールドを追加しました。

- Gemini Thinking (`google_thinking_config.thinking_level` 等) や Anthropic の `extra_headers`、OpenAI の各種 reasoning オプションなど、pydantic-ai 側で追加されるフィールドを mixseek-core 側で再定義することなく TOML から指定可能に。
- pydantic-ai のバージョンアップだけで Provider の進化に追従でき、運用追従コストを排除。
- 共通ユーティリティ `build_model_settings()` を `src/mixseek/core/model_settings.py` に新設し、4 箇所に散らばっていた `ModelSettings` 構築ロジックを集約。
- 副次的に `judgment_client.py:100` の `"stop"` 誤キー (正しくは `"stop_sequences"`) も自動的に解消。

## 仕様

### 合成順序 (後勝ち)

1. `model_settings` (Provider 共通 pass-through)
2. `google_model_settings` (Google モデルのときのみ、他は警告ログのうえ無視)
3. 既存の個別フィールド (`temperature`, `max_tokens`, `top_p`, `seed`, `stop_sequences`, `timeout_seconds`) ← 最優先

### TOML 記述例

```toml
[team.leader]
model = "google-gla:gemini-3.1-flash-lite"
temperature = 0.0

[team.leader.model_settings]
parallel_tool_calls = true

[team.leader.google_model_settings]
google_thinking_config = { thinking_level = "HIGH", include_thoughts = true }
```

### 設計判断

- **検証なし (pass-through)**: pydantic-ai 側が `TypedDict` で検証なしの設計を採用しているため、その思想に揃える。Provider 固有スキーマを mixseek-core で再定義すると追従コストが高い。値の誤りは Provider API 呼び出し時のエラーで顕在化する。
- **`google_model_settings` の Provider 不整合時**: 警告ログ + 無視 (実行継続)。Provider 切り替え時の事故を回避しつつ stale config を可視化。
- **PromptBuilder は対象外**: Jinja2 テンプレート展開のみで LLM 呼び出しを持たないため。

## 変更ファイル

### コア実装
- `src/mixseek/core/model_settings.py` (新規) — `build_model_settings()` ユーティリティ
- `src/mixseek/config/schema.py` — 4 Settings + Workflow `AgentExecutorSettings` にフィールド追加
- `src/mixseek/agents/leader/config.py` — レガシー互換 2 クラスにフィールド追加
- `src/mixseek/models/member_agent.py` — `MemberAgentConfig` にフィールド追加
- `src/mixseek/models/evaluation_config.py` — `MetricConfig` / `LLMDefaultConfig` + getter 追加
- `src/mixseek/config/member_agent_loader.py` — 変換時の propagation
- `src/mixseek/agents/leader/agent.py`, `src/mixseek/agents/member/base.py`, `src/mixseek/evaluator/llm_client.py`, `src/mixseek/evaluator/metrics/base.py`, `src/mixseek/evaluator/evaluator.py`, `src/mixseek/round_controller/judgment_client.py` — `build_model_settings` 経由に統一

### テスト
- `tests/unit/test_model_settings.py` (新規、16 件、全 pass)

### ドキュメント
- `docs/configuration-reference.md` — Leader / Member / Evaluator (llm_default + metrics) / Judgment の各テーブルに 2 行追加 + 設定例 TOML 拡張
- `docs/advanced-features.md` — 「pydantic-ai ModelSettings の透過設定」セクション新設
- `docs/configuration-guide.md` — 合成順序の admonition 追記
- `examples/team-inline-agents.toml` — Thinking 設定例コメント追加

## Test plan

- [x] 新規ユニットテスト 16 件 (`tests/unit/test_model_settings.py`) 全 pass
- [x] 既存ユニットテスト 958 件 pass (`uv run pytest tests/unit`)
- [x] `uv run ruff check` クリア
- [x] `uv run ruff format --check` クリア
- [x] `uv run mypy` 変更ファイル群でエラーなし
- [x] `uv run --group docs python -m sphinx -M html docs docs/_build -W --keep-going` 警告ゼロ
- [x] (動作確認) Gemini 3 系モデルで `google_thinking_config.thinking_level = \"HIGH\"` を実 API 経由で動作確認
- [x] (動作確認) anthropic モデルで `google_model_settings` 指定時に警告ログが出ることを確認
- [x] (動作確認) `model_settings.temperature` と個別 `temperature` を併設して個別フィールドが優先されることを確認

Created by 🤖Claude