### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [develop]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how you create a framework for complex LLM workflows with its hierarchical task delegation and round-based evaluation. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [HIGH] Agent uses web search built-in without before_tool_callback
   File: examples/custom_agents/adk_research/agent.py
   What it means: This LlmAgent is wired with a web search built-in (the google_search instance, GoogleSearchTool, or VertexAiSearchTool) but has no before_tool_callback.

2. [HIGH] Pydantic AI agent wires the code-execution native tool
   File: src/mixseek/agents/member/code_execution.py
   What it means: This agent wires Pydantic AI's CodeExecutionTool (via capabilities= or builtin_tools=), a provider-native tool that executes code the model generates.

3. [HIGH] Pydantic AI agent wires the code-execution native tool
   File: src/mixseek/agents/member/code_execution.py
   What it means: This agent wires Pydantic AI's CodeExecutionTool (via capabilities= or builtin_tools=), a provider-native tool that executes code the model generates.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)